### PR TITLE
UI: fix production build mode + create executable Spline UI jar

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -154,6 +154,12 @@
                     <artifactId>apache-rat-plugin</artifactId>
                     <version>0.12</version>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.tomcat.maven</groupId>
+                    <artifactId>tomcat7-maven-plugin</artifactId>
+                    <version>2.1</version>
+                    <!-- version 2.2 is buggy -->
+                </plugin>
             </plugins>
         </pluginManagement>
 

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -76,7 +76,7 @@
     </dependencies>
 
     <build>
-        <finalName>sparklineage-${project.version}</finalName>
+        <finalName>spline-ui-${project.version}</finalName>
         <plugins>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
@@ -211,6 +211,25 @@
                         </manifestEntries>
                     </archive>
                 </configuration>
+            </plugin>
+
+            <plugin>
+                <!-- http://tomcat.apache.org/maven-plugin-trunk/executable-war-jar.html -->
+                <groupId>org.apache.tomcat.maven</groupId>
+                <artifactId>tomcat7-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>tomcat-run</id>
+                        <goals>
+                            <goal>exec-war-only</goal>
+                        </goals>
+                        <phase>package</phase>
+                        <configuration>
+                            <path>/</path>
+                            <finalName>${project.build.finalName}.exec.jar</finalName>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/web/ui/package.json
+++ b/web/ui/package.json
@@ -5,6 +5,7 @@
     "@types/requirejs": "~2.1.28",
     "angular2-template-loader": "~0.6.2",
     "awesome-typescript-loader": "~3.1.2",
+    "clean-webpack-plugin": "~0.1.16",
     "concurrently": "~3.4.0",
     "css-loader": "~0.27.3",
     "file-loader": "~0.10.1",

--- a/web/ui/package.json
+++ b/web/ui/package.json
@@ -54,6 +54,6 @@
     "dev-http-server": "webpack-dev-server",
     "dev-rest-server": "json-server mock-rest-api/db.js",
     "dev-build": "webpack",
-    "prod-build": "webpack -p --no-color"
+    "prod-build": "NODE_ENV='production' webpack -p --no-color"
   }
 }

--- a/web/ui/src/main.ts
+++ b/web/ui/src/main.ts
@@ -20,5 +20,9 @@ import "reflect-metadata";
 import "zone.js";
 import {platformBrowserDynamic} from "@angular/platform-browser-dynamic";
 import {AppModule} from "./app/app.module";
+import {enableProdMode} from '@angular/core';
+
+declare var __PRODUCTION_MODE__:boolean
+if (__PRODUCTION_MODE__) enableProdMode()
 
 platformBrowserDynamic().bootstrapModule(AppModule)

--- a/web/ui/webpack.config.js
+++ b/web/ui/webpack.config.js
@@ -16,9 +16,12 @@
 
 var webpack = require('webpack')
 var path = require('path')
-var isProd = process.env.NODE_ENV === "production";
+var CleanWebpackPlugin = require('clean-webpack-plugin')
+
+var isProd = process.env.NODE_ENV === "production"
 
 var commonPlugins = [
+    new CleanWebpackPlugin(['dist']),
     new webpack.ContextReplacementPlugin(
         /angular(\\|\/)core(\\|\/)(esm(\\|\/)src|src)(\\|\/)linker/,
         path.resolve(__dirname, 'doesnotexist/')

--- a/web/ui/webpack.config.js
+++ b/web/ui/webpack.config.js
@@ -22,6 +22,9 @@ var isProd = process.env.NODE_ENV === "production"
 
 var commonPlugins = [
     new CleanWebpackPlugin(['dist']),
+    new webpack.DefinePlugin({
+        __PRODUCTION_MODE__: isProd
+    }),
     new webpack.ContextReplacementPlugin(
         /angular(\\|\/)core(\\|\/)(esm(\\|\/)src|src)(\\|\/)linker/,
         path.resolve(__dirname, 'doesnotexist/')
@@ -46,8 +49,8 @@ module.exports = {
         extensions: ['.webpack.js', '.web.js', '.ts', '.tsx', '.js', '.jsx', '.less', '.css', '.html']
     },
     plugins: commonPlugins.concat(isProd
-        ? [new webpack.optimize.UglifyJsPlugin()]
-        : []
+            ? [/* prod build plugins */]
+            : [/* dev build plugins */]
     ),
     module: {
         loaders: [


### PR DESCRIPTION
When building Web/UI module an executable standalone _spline-ui.exec.jar_ is produced in addition to a standard WAR file. It allows users to run the Spline Web UI as a standalone app without having to care about a Web container to deploy a WAR file to.

To run Spline Web UI:
`java -jar spline-ui.exec.jar -Dspline.mongodb.url=... -Dspline.mongodb.name=... `