### PR TITLE
#12 Support for MongoDB 3.6

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -356,6 +356,11 @@
                 <version>${salat.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.mongodb</groupId>
+                <artifactId>mongo-java-driver</artifactId>
+                <version>3.6.0</version>
+            </dependency>
+            <dependency>
                 <groupId>org.json4s</groupId>
                 <artifactId>json4s-ext_${scala.compat.version}</artifactId>
                 <version>${json4s.version}</version>


### PR DESCRIPTION
Upgrade mongo java driver to support mongodb server 3.6