### PR TITLE
spline-57 refactoring

### DIFF
--- a/web/src/main/scala/za/co/absa/spline/web/rest/service/LineageService.scala
+++ b/web/src/main/scala/za/co/absa/spline/web/rest/service/LineageService.scala
@@ -161,31 +161,13 @@ class LineageService
         dataLineage.appName
       )
 
-      val datasets = {
-        val datasetIds = inputDatasetIds.toSet + outputDatasetId
-        dataLineage.datasets.filter(ds => datasetIds(ds.id))
-      }
+      val reducedLineage = dataLineage.copy(operations = Seq(composite)).rectified
 
-      val attributes = {
-        val attributeIds = datasets.flatMap(_.schema.attrs).toSet
-        dataLineage.attributes.filter(a => attributeIds(a.id))
-      }
-
-      val dataTypes = {
-        val collectedDTs = mutable.Set.empty[DataType]
-        val dtById = dataLineage.dataTypes.groupBy(_.id).mapValues(_.head)
-
-        def collectRecursively(dtId: UUID): Unit = {
-          val dt = dtById(dtId)
-          if (collectedDTs.add(dt))
-            dt.childDataTypeIds.foreach(collectRecursively)
-        }
-
-        attributes.foreach(a => collectRecursively(a.dataTypeId))
-        collectedDTs.toSeq
-      }
-
-      CompositeWithDependencies(composite, datasets, attributes, dataTypes)
+      CompositeWithDependencies(
+        composite,
+        reducedLineage.datasets,
+        reducedLineage.attributes,
+        reducedLineage.dataTypes)
     }
 
 


### PR DESCRIPTION
Moving the lineage rectifying algorithm to the `DataLineage` companion object and use that method from both `LineageProjectionMerger` and REST `LineageService`