### PR TITLE
spline-62 MongoDB: fix security error on "client.databaseNames()"

### DIFF
--- a/persistence/mongo/src/main/scala/za/co/absa/spline/persistence/mongo/MongoConnection.scala
+++ b/persistence/mongo/src/main/scala/za/co/absa/spline/persistence/mongo/MongoConnection.scala
@@ -26,7 +26,9 @@ trait MongoConnection {
 class MongoConnectionImpl(dbUrl: String, dbName: String) extends MongoConnection {
   private val client: MongoClient = MongoClient(MongoClientURI(dbUrl))
 
-  require(client.databaseNames != null) // check if the connection can be established
-
-  val db: MongoDB = client.getDB(dbName)
+  val db: MongoDB = {
+    val db = client.getDB(dbName)
+    require(db.stats.ok)
+    db
+  }
 }

--- a/persistence/mongo/src/test/scala/za/co/absa/spline/persistence/mongo/MongoDataLineagePersistenceSpecBase.scala
+++ b/persistence/mongo/src/test/scala/za/co/absa/spline/persistence/mongo/MongoDataLineagePersistenceSpecBase.scala
@@ -80,5 +80,9 @@ abstract class MongoDataLineagePersistenceSpecBase
   }
 
   override protected def afterEach(): Unit =
-    mongoConnection.db.collectionNames.foreach(mongoConnection.db(_).drop)
+    for {
+      collectionName <- mongoConnection.db.collectionNames
+      if !(collectionName startsWith "system.")
+      collection = mongoConnection.db(collectionName)
+    } collection.drop()
 }


### PR DESCRIPTION
replace "client.databaseNames" with "db.stats.ok" as a connectivity check.