### PR TITLE
spline-61 MongoDB: Simplify connection settings

### DIFF
--- a/persistence/mongo/src/main/scala/za/co/absa/spline/persistence/mongo/MongoConnection.scala
+++ b/persistence/mongo/src/main/scala/za/co/absa/spline/persistence/mongo/MongoConnection.scala
@@ -18,17 +18,31 @@ package za.co.absa.spline.persistence.mongo
 
 import com.mongodb.casbah.Imports.MongoClientURI
 import com.mongodb.casbah.{MongoClient, MongoDB}
+import org.slf4s.Logging
 
 trait MongoConnection {
   def db: MongoDB
 }
 
-class MongoConnectionImpl(dbUrl: String, dbName: String) extends MongoConnection {
-  private val client: MongoClient = MongoClient(MongoClientURI(dbUrl))
+class MongoConnectionImpl
+(
+  dbUrl: String,
+
+  // TODO: REMOVE in Spline 0.4. Deprecated since 0.3.6
+  dbName: => String = throw new IllegalArgumentException("The connection string must contain a database name")
+) extends MongoConnection
+  with Logging {
+
+  private val clientUri = MongoClientURI(dbUrl)
+  private val client: MongoClient = MongoClient(clientUri)
+
 
   val db: MongoDB = {
-    val db = client.getDB(dbName)
-    require(db.stats.ok)
-    db
+    val databaseName = clientUri.database getOrElse dbName
+    log debug s"Preparing connection: $dbUrl, database = $databaseName"
+    val database = client.getDB(databaseName)
+    require(database.stats.ok, "database is not OK")
+    log debug s"Connected: $dbUrl, database = $databaseName"
+    database
   }
 }

--- a/persistence/mongo/src/main/scala/za/co/absa/spline/persistence/mongo/MongoPersistenceFactory.scala
+++ b/persistence/mongo/src/main/scala/za/co/absa/spline/persistence/mongo/MongoPersistenceFactory.scala
@@ -38,14 +38,9 @@ class MongoPersistenceFactory(configuration: Configuration) extends PersistenceF
   import MongoPersistenceFactory._
   import za.co.absa.spline.common.ConfigurationImplicits._
 
-  private val mongoConnection = {
-    val dbUrl = configuration getRequiredString mongoDbUrlKey
-    val dbName = configuration getRequiredString mongoDbNameKey
-    log debug s"Preparing connection: $dbUrl/$dbName"
-    val connection = new MongoConnectionImpl(dbUrl, dbName)
-    log info s"Connected: $dbUrl/$dbName"
-    connection
-  }
+  private val mongoConnection = new MongoConnectionImpl(
+    dbUrl = configuration getRequiredString mongoDbUrlKey,
+    dbName = configuration getRequiredString mongoDbNameKey)
 
   private val dao = new MultiVersionLineageDAO(
     new LineageDAOv3(mongoConnection),

--- a/persistence/mongo/src/test/scala/za/co/absa/spline/persistence/mongo/MongoTestProperties.scala
+++ b/persistence/mongo/src/test/scala/za/co/absa/spline/persistence/mongo/MongoTestProperties.scala
@@ -22,8 +22,7 @@ object MongoTestProperties {
 
   import za.co.absa.spline.common.ConfigurationImplicits._
 
-  private val mongoDBUri: String = new SystemConfiguration() getRequiredString "test.spline.mongodb.url"
-  private val mongoDBName: String = new SystemConfiguration() getRequiredString "test.spline.mongodb.name"
+  private val conf = new SystemConfiguration()
 
-  val mongoConnection: MongoConnection = new MongoConnectionImpl(mongoDBUri, mongoDBName)
+  val mongoConnection = new MongoConnectionImpl(conf getRequiredString "test.spline.mongodb.url")
 }


### PR DESCRIPTION
The database name to is be specified in the connection URL.

`spline.mongodb.name` parameter is left for backward compatibility and is only used when there is no database name specified in the connection string.