### PR TITLE
Cosmos DB compatible search

### DIFF
--- a/persistence/mongo/src/main/scala/za/co/absa/spline/persistence/mongo/dao/BaselineLineageDAO.scala
+++ b/persistence/mongo/src/main/scala/za/co/absa/spline/persistence/mongo/dao/BaselineLineageDAO.scala
@@ -31,6 +31,7 @@ import za.co.absa.spline.persistence.api.DataLineageReader.{PageRequest, Timesta
 import za.co.absa.spline.persistence.mongo.MongoImplicits._
 import za.co.absa.spline.persistence.mongo.dao.BaselineLineageDAO.Component
 import za.co.absa.spline.persistence.mongo.dao.BaselineLineageDAO.Component.SubComponent
+import za.co.absa.spline.persistence.mongo.dao.BaselineLineageDAO.NON_WORD_CHAR
 import za.co.absa.spline.persistence.mongo.{DBCursorToCloseableIterableAdapter, MongoConnection}
 
 import scala.collection.JavaConverters._
@@ -46,10 +47,6 @@ abstract class BaselineLineageDAO extends VersionedLineageDAO with Logging {
 
   protected lazy val dataLineageCollection: DBCollection = getMongoCollectionForComponent(Component.Root)
   protected lazy val operationCollection: DBCollection = getMongoCollectionForComponent(Component.Operation)
-
-  object BaselineLineageDao {
-    final val NON_WORD_CHAR = "\\W".r
-  }
 
   override def save(lineage: DBObject)(implicit e: ExecutionContext): Future[Unit] = {
     val lineageId = lineage.get(idField).toString
@@ -254,7 +251,7 @@ abstract class BaselineLineageDAO extends VersionedLineageDAO with Logging {
     * @return A regular expression searching for the exact literal text string
     */
   private def quoteSafely(text: String): String = {
-    BaselineLineageDao.NON_WORD_CHAR.replaceAllIn(text, m => s"\\\\${m.matched}")
+    NON_WORD_CHAR.replaceAllIn(text, m => s"\\\\${m.matched}")
   }
 
   /**
@@ -296,6 +293,8 @@ abstract class BaselineLineageDAO extends VersionedLineageDAO with Logging {
 }
 
 object BaselineLineageDAO {
+
+  final val NON_WORD_CHAR = "\\W".r
 
   abstract class Component(val name: String)
 

--- a/persistence/mongo/src/main/scala/za/co/absa/spline/persistence/mongo/dao/BaselineLineageDAO.scala
+++ b/persistence/mongo/src/main/scala/za/co/absa/spline/persistence/mongo/dao/BaselineLineageDAO.scala
@@ -47,7 +47,9 @@ abstract class BaselineLineageDAO extends VersionedLineageDAO with Logging {
   protected lazy val dataLineageCollection: DBCollection = getMongoCollectionForComponent(Component.Root)
   protected lazy val operationCollection: DBCollection = getMongoCollectionForComponent(Component.Operation)
 
-  private final val NON_WORD_CHAR = "\\W".r
+  object BaselineLineageDao {
+    final val NON_WORD_CHAR = "\\W".r
+  }
 
   override def save(lineage: DBObject)(implicit e: ExecutionContext): Future[Unit] = {
     val lineageId = lineage.get(idField).toString
@@ -251,8 +253,8 @@ abstract class BaselineLineageDAO extends VersionedLineageDAO with Logging {
     * @param text A string
     * @return A regular expression searching for the exact literal text string
     */
-  protected def quoteSafely(text: String): String = {
-    return NON_WORD_CHAR.replaceAllIn(text, "\\\\" + _.matched)
+  private def quoteSafely(text: String): String = {
+    BaselineLineageDao.NON_WORD_CHAR.replaceAllIn(text, m => s"\\\\${m.matched}")
   }
 
   /**

--- a/persistence/mongo/src/main/scala/za/co/absa/spline/persistence/mongo/dao/BaselineLineageDAO.scala
+++ b/persistence/mongo/src/main/scala/za/co/absa/spline/persistence/mongo/dao/BaselineLineageDAO.scala
@@ -36,6 +36,7 @@ import za.co.absa.spline.persistence.mongo.{DBCursorToCloseableIterableAdapter, 
 
 import scala.collection.JavaConverters._
 import scala.concurrent.{ExecutionContext, Future, blocking}
+import scala.util.matching.Regex.quoteReplacement
 
 abstract class BaselineLineageDAO extends VersionedLineageDAO with Logging {
 
@@ -251,7 +252,7 @@ abstract class BaselineLineageDAO extends VersionedLineageDAO with Logging {
     * @return A regular expression searching for the exact literal text string
     */
   private def quoteSafely(text: String): String = {
-    NON_WORD_CHAR.replaceAllIn(text, m => s"\\\\${m.matched}")
+    NON_WORD_CHAR.replaceAllIn(text, m => s"\\\\${quoteReplacement(m.matched)}")
   }
 
   /**

--- a/persistence/mongo/src/test/scala/za/co/absa/spline/persistence/mongo/MongoDataLineageReaderSpec.scala
+++ b/persistence/mongo/src/test/scala/za/co/absa/spline/persistence/mongo/MongoDataLineageReaderSpec.scala
@@ -46,8 +46,8 @@ class MongoDataLineageReaderSpec extends MongoDataLineagePersistenceSpecBase wit
       createDataLineage("appID5", "App Five", path = "file://some/path/5.csv", timestamp = 105),
       createDataLineage("appID6", "App Six", path = "file://some/path/6.csv", timestamp = 106),
       createDataLineage("appID7", "App Seven", path = "file://some/path/7.csv", timestamp = 107),
-      createDataLineage("appID8", "App Eight (text)", path = "file://some/path/8.csv", timestamp = 108),
-      createDataLineage("appID9", "App Nine (text2)", path = "file://some/path/9.csv", timestamp = 109)
+      createDataLineage("appID8", "App Eight (text) a\\'b$1", path = "file://some/path/8.csv", timestamp = 108),
+      createDataLineage("appID9", "App Nine (text2) a'b", path = "file://some/path/9.csv", timestamp = 109)
     )
 
     it("should load descriptions from a database.") {
@@ -115,9 +115,15 @@ class MongoDataLineageReaderSpec extends MongoDataLineagePersistenceSpecBase wit
     it("should search verbatim text") {
       for {
         _ <- Future.sequence(testLineages.map(mongoWriter.store))
-        page <- mongoReader.findDatasets("(text)", EntireLatestContent)
+        set1 <- mongoReader.findDatasets("(text)", EntireLatestContent)
+        set2 <- mongoReader.findDatasets("a\\'b", EntireLatestContent)
+        set3 <- mongoReader.findDatasets("a\\\\'b", EntireLatestContent)
+        set4 <- mongoReader.findDatasets("a\\'b$1", EntireLatestContent)
       } yield {
-        page should consistOfItemsWithAppIds[PersistedDatasetDescriptor]("appID8")
+        set1 should consistOfItemsWithAppIds[PersistedDatasetDescriptor]("appID8")
+        set2 should consistOfItemsWithAppIds[PersistedDatasetDescriptor]("appID8")
+        set3.iterator shouldBe empty
+        set4 should consistOfItemsWithAppIds[PersistedDatasetDescriptor]("appID8")
       }
     }
   }

--- a/persistence/mongo/src/test/scala/za/co/absa/spline/persistence/mongo/MongoDataLineageReaderSpec.scala
+++ b/persistence/mongo/src/test/scala/za/co/absa/spline/persistence/mongo/MongoDataLineageReaderSpec.scala
@@ -46,8 +46,8 @@ class MongoDataLineageReaderSpec extends MongoDataLineagePersistenceSpecBase wit
       createDataLineage("appID5", "App Five", path = "file://some/path/5.csv", timestamp = 105),
       createDataLineage("appID6", "App Six", path = "file://some/path/6.csv", timestamp = 106),
       createDataLineage("appID7", "App Seven", path = "file://some/path/7.csv", timestamp = 107),
-      createDataLineage("appID8", "App Eight", path = "file://some/path/8.csv", timestamp = 108),
-      createDataLineage("appID9", "App Nine", path = "file://some/path/9.csv", timestamp = 109)
+      createDataLineage("appID8", "App Eight (text)", path = "file://some/path/8.csv", timestamp = 108),
+      createDataLineage("appID9", "App Nine (text2)", path = "file://some/path/9.csv", timestamp = 109)
     )
 
     it("should load descriptions from a database.") {
@@ -109,6 +109,15 @@ class MongoDataLineageReaderSpec extends MongoDataLineagePersistenceSpecBase wit
         foundSingleMatch should consistOfItemsWithAppIds[PersistedDatasetDescriptor](searchingLineage.appId)
         noResultByPrefix.iterator shouldBe empty
         noResultBySuffix.iterator shouldBe empty
+      }
+    }
+
+    it("should search verbatim text") {
+      for {
+        _ <- Future.sequence(testLineages.map(mongoWriter.store))
+        page <- mongoReader.findDatasets("(text)", EntireLatestContent)
+      } yield {
+        page should consistOfItemsWithAppIds[PersistedDatasetDescriptor]("appID8")
       }
     }
   }


### PR DESCRIPTION
Escape special characters one by one when searching Mongo DB, rather than using Pattern.quote(), for Cosmos DB compatibility. (Azure Cosmos DB can be configured with a Mongo DB compatible API, but it supports ECMAScript regexes instead of PCRE).

Fixes AbsaOSS/spline#166.