### PR TITLE
spline #197 - Remove documentation for deprecated `spline.mongodb.nam…

### DIFF
--- a/sample/README.md
+++ b/sample/README.md
@@ -1,6 +1,6 @@
 Run sample command:
 ```
-mvn test -Psamples -Dspline.mongodb.url=... -Dspline.mongodb.name=... -DsampleClass=za.co.absa.spline.sample.SampleJob1
+mvn test -Psamples -Dspline.mongodb.url=... -DsampleClass=za.co.absa.spline.sample.SampleJob1
 ``` 
 
 ---

--- a/sample/src/main/resources/spline.properties
+++ b/sample/src/main/resources/spline.properties
@@ -27,7 +27,6 @@
 #
 # spline.persistence.factory=za.co.absa.spline.persistence.mongo.MongoPersistenceFactory
 # spline.mongodb.url=
-# spline.mongodb.name=
 #
 #
 # Set of properties for setting up persistence to files on HDFS.


### PR DESCRIPTION
…e` conf param