### PR TITLE
spline #240 noSuchMethod exception in tests

### DIFF
--- a/spark-adapter-api/pom.xml
+++ b/spark-adapter-api/pom.xml
@@ -51,6 +51,12 @@
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-sql-kafka-0-10_${scala.compat.version}</artifactId>
+            <exclusions>
+                <exclusion>
+                <groupId>net.jpountz.lz4</groupId>
+                <artifactId>lz4</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
There is dependency conflict between "spark sql kafka" library and "spark core" in 2.3.x . This excludes older version of LZ4 library