### PR TITLE
#345: File separator issues prevent build on Windows

### DIFF
--- a/client-ui/assembly.xml
+++ b/client-ui/assembly.xml
@@ -25,7 +25,7 @@
   <fileSets>
     <fileSet>
       <directory>${project.basedir}/dist/ui2</directory>
-      <outputDirectory>/</outputDirectory>
+      <outputDirectory>./</outputDirectory>
     </fileSet>
   </fileSets>
 </assembly>

--- a/client-ui/package-lock.json
+++ b/client-ui/package-lock.json
@@ -1439,7 +1439,7 @@
     },
     "@types/node": {
       "version": "8.9.5",
-      "resolved": "http://registry.npmjs.org/@types/node/-/node-8.9.5.tgz",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.9.5.tgz",
       "integrity": "sha512-jRHfWsvyMtXdbhnz5CVHxaBgnV6duZnPlQuRSo/dm/GnmikNcmZhxIES4E9OZjUmQ8C+HCl4KJux+cXN/ErGDQ==",
       "dev": true
     },
@@ -5680,7 +5680,7 @@
     },
     "get-stream": {
       "version": "3.0.0",
-      "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
       "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
       "dev": true
     },
@@ -10502,7 +10502,7 @@
     },
     "sprintf-js": {
       "version": "1.0.3",
-      "resolved": "http://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },


### PR DESCRIPTION
* Using ${file.separator} instead of / on the critical places