### PR TITLE
Add custom attribute lineage extractor and Custom dispatcher

### DIFF
--- a/spark/agent/src/main/scala/za/co/absa/spline/harvester/LineageHarvesterFactory.scala
+++ b/spark/agent/src/main/scala/za/co/absa/spline/harvester/LineageHarvesterFactory.scala
@@ -21,6 +21,7 @@ import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.execution.SparkPlan
 import za.co.absa.spline.harvester.conf.SplineConfigurer.SplineMode.SplineMode
+import za.co.absa.spline.harvester.converter.AbstractAttributeLineageExtractor
 
 import scala.language.postfixOps
 
@@ -28,12 +29,12 @@ import scala.language.postfixOps
  *
  * @param hadoopConfiguration A hadoop configuration
  */
-class LineageHarvesterFactory(hadoopConfiguration: Configuration, splineMode: SplineMode) {
+class LineageHarvesterFactory(hadoopConfiguration: Configuration, splineMode: SplineMode, splineAttrLineageExtractor: AbstractAttributeLineageExtractor) {
 
   /** A main method of the object that performs transformation of Spark internal structures to library lineage representation.
    *
    * @return A lineage representation
    */
   def harvester(logicalPlan: LogicalPlan, executedPlan: Option[SparkPlan], session: SparkSession): LineageHarvester =
-    new LineageHarvester(logicalPlan, executedPlan, session)(hadoopConfiguration, splineMode)
+    new LineageHarvester(logicalPlan, executedPlan, session)(hadoopConfiguration, splineMode, splineAttrLineageExtractor)
 }

--- a/spark/agent/src/main/scala/za/co/absa/spline/harvester/ModelConstants.scala
+++ b/spark/agent/src/main/scala/za/co/absa/spline/harvester/ModelConstants.scala
@@ -25,8 +25,10 @@ object ModelConstants {
 
   object ExecutionPlanExtra {
     val AppName = "appName"
+    val AppId = "appId"
     val DataTypes = "dataTypes"
     val Attributes = "attributes"
+    val AttributeLineage = "attributeLineage"
   }
 
   object ExecutionEventExtra {

--- a/spark/agent/src/main/scala/za/co/absa/spline/harvester/conf/SplineConfigurer.scala
+++ b/spark/agent/src/main/scala/za/co/absa/spline/harvester/conf/SplineConfigurer.scala
@@ -18,6 +18,7 @@ package za.co.absa.spline.harvester.conf
 
 import za.co.absa.spline.harvester.QueryExecutionEventHandler
 import za.co.absa.spline.harvester.dispatcher.{HttpLineageDispatcher, LineageDispatcher}
+import za.co.absa.spline.harvester.converter.{AbstractAttributeLineageExtractor, DisabledAttributeLineageExtractor}
 
 /**
   * The trait describes settings needed for initialization of the library.
@@ -25,6 +26,11 @@ import za.co.absa.spline.harvester.dispatcher.{HttpLineageDispatcher, LineageDis
 trait SplineConfigurer {
 
   import SplineConfigurer.SplineMode._
+
+  /**
+   * @return [[za.co.absa.spline.harvester.converter.AbstractAttributeLineageExtractor]]
+   */
+  def attributeLineageExtractor: AbstractAttributeLineageExtractor = new DisabledAttributeLineageExtractor
 
   /**
     * A listener handling events from batch processing

--- a/spark/agent/src/main/scala/za/co/absa/spline/harvester/converter/AttributeLineageExtractor.scala
+++ b/spark/agent/src/main/scala/za/co/absa/spline/harvester/converter/AttributeLineageExtractor.scala
@@ -1,0 +1,26 @@
+package za.co.absa.spline.harvester.converter
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.execution.SparkPlan
+import za.co.absa.spline.common.transformations.AbstractConverter
+import za.co.absa.spline.harvester.qualifier.PathQualifier
+
+
+case class LineageExtractionContext(
+                                 logicalPlan: LogicalPlan,
+                                 executedPlanOpt: Option[SparkPlan],
+                                 session: SparkSession,
+                                 pathQualifier: PathQualifier,
+                                 hadoopConfiguration: Configuration
+                               )
+
+abstract class AbstractAttributeLineageExtractor extends AbstractConverter {
+  override type From = LineageExtractionContext
+  override type To = Option[Any]
+}
+
+class DisabledAttributeLineageExtractor extends AbstractAttributeLineageExtractor {
+  def convert(arg: LineageExtractionContext): Option[Any] = None
+}

--- a/spark/agent/src/main/scala/za/co/absa/spline/harvester/converter/AttributeLineageExtractor.scala
+++ b/spark/agent/src/main/scala/za/co/absa/spline/harvester/converter/AttributeLineageExtractor.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package za.co.absa.spline.harvester.converter
 
 import org.apache.hadoop.conf.Configuration


### PR DESCRIPTION
* Add support for adding a `custom attribute lineage extractor`, fixes https://github.com/AbsaOSS/spline/issues/464
  - for the moment this is made very generic, so people can plug in their own implementation (returning `Option[Any]`)
  - later spline could provide its own default (hopefully, extensible with external additions)
  - a partial solution for #114 
* Add support for a `Custom dispatcher`, fixes https://github.com/AbsaOSS/spline/issues/463

@wajda