### PR TITLE
spline #522 Add DataOperation.childIds default value

### DIFF
--- a/examples/src/main/python/python_example.py
+++ b/examples/src/main/python/python_example.py
@@ -36,7 +36,7 @@ This is simplest example of how to track a lineage with Spline.
 """
 
 # Enable Spline tracking:
-sc._jvm.za.co.absa.spline.core\
+sc._jvm.za.co.absa.spline.harvester\
     .SparkLineageInitializer.enableLineageTracking(spark._jsparkSession)
 
 # Execute a job:

--- a/producer-model/src/main/scala/za/co/absa/spline/producer/model/operationModel.scala
+++ b/producer-model/src/main/scala/za/co/absa/spline/producer/model/operationModel.scala
@@ -27,7 +27,7 @@ sealed trait OperationLike {
 
 case class DataOperation(
   override val id: Int,
-  override val childIds: Seq[Int],
+  override val childIds: Seq[Int] = Seq.empty,
   override val schema: Option[Any] = None, // None means that that the schema is either the same as in the child operation, or unknown.
   override val params: Map[String, Any] = Map.empty,
   override val extra: Map[String, Any] = Map.empty


### PR DESCRIPTION
Add an empty default value to the `DataOperation.childIds` property to fix deserialization issue