### PR TITLE
SSL support in the admin client - draft 

### DIFF
--- a/admin/src/main/scala/za/co/absa/spline/admin/AdminCLI.scala
+++ b/admin/src/main/scala/za/co/absa/spline/admin/AdminCLI.scala
@@ -22,6 +22,7 @@ import za.co.absa.commons.buildinfo.BuildInfo
 import za.co.absa.spline.admin.AdminCLI.AdminCLIConfig
 import za.co.absa.spline.persistence.OnDBExistsAction.{Drop, Fail, Skip}
 import za.co.absa.spline.persistence.{ArangoConnectionURL, ArangoInit}
+import za.co.absa.spline.persistence.ArangoConnectionURL.{ArangoDbScheme, ArangoSecureDbScheme}
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
@@ -46,9 +47,12 @@ class AdminCLI(arangoInit: ArangoInit) {
         opt[String]('t', "timeout")
           text s"Timeout in format `<length><unit>` or `Inf` for infinity. Default is ${DBInit().timeout}"
           action { case (s, c@AdminCLIConfig(cmd: DBCommand)) => c.copy(cmd.timeout = Duration(s)) },
+        opt[Unit]('k', "insecure")
+          text s"Allow insecure server connections when using SSL; disallowed by default"
+          action { case (_, c@AdminCLIConfig(cmd: DBCommand)) => c.copy(cmd.insecure = true) },
         arg[String]("<db_url>")
           required()
-          text "ArangoDB connection string in the format: arangodb://[user[:password]@]host[:port]/database"
+          text s"ArangoDB connection string in the format: $ArangoDbScheme|$ArangoSecureDbScheme://[user[:password]@]host[:port]/database"
           action { case (url, c@AdminCLIConfig(cmd: DBCommand)) => c.copy(cmd.dbUrl = url) })
 
       (cmd("db-init")
@@ -74,6 +78,8 @@ class AdminCLI(arangoInit: ArangoInit) {
           failure("No command given")
         case AdminCLIConfig(cmd: DBCommand) if cmd.dbUrl == null =>
           failure("DB connection string is required")
+        case AdminCLIConfig(cmd: DBCommand) if cmd.dbUrl.startsWith(ArangoSecureDbScheme) && !cmd.insecure =>
+          failure("At the moment, only unsecure SSL is supported; when using the secure scheme, please add the -k option to skip server certificate verification altogether")
         case AdminCLIConfig(cmd: DBInit) if cmd.force && cmd.skip =>
           failure("Options '--force' and '--skip' cannot be used together")
         case _ =>
@@ -87,7 +93,7 @@ class AdminCLI(arangoInit: ArangoInit) {
       .cmd
 
     command match {
-      case DBInit(url, timeout, force, skip) =>
+      case DBInit(url, timeout, _, force, skip) =>
         val onExistsAction = (force, skip) match {
           case (true, false) => Drop
           case (false, true) => Skip
@@ -96,7 +102,7 @@ class AdminCLI(arangoInit: ArangoInit) {
         val wasInitialized = Await.result(arangoInit.initialize(ArangoConnectionURL(url), onExistsAction), timeout)
         if (!wasInitialized) println(ansi"%yellow{Skipped. DB is already initialized}")
 
-      case DBUpgrade(url, timeout) =>
+      case DBUpgrade(url, timeout, _) =>
         Await.result(arangoInit.upgrade(ArangoConnectionURL(url)), timeout)
     }
 

--- a/admin/src/main/scala/za/co/absa/spline/admin/commands.scala
+++ b/admin/src/main/scala/za/co/absa/spline/admin/commands.scala
@@ -25,33 +25,40 @@ sealed trait DBCommand extends Command {
 
   def timeout: Duration
 
-  def timeout_=(t: Duration): Self = selfCopy(dbUrl, t)
+  def insecure: Boolean
 
-  def dbUrl_=(url: String): Self = selfCopy(url, timeout)
+  def timeout_=(t: Duration): Self = selfCopy(dbUrl, t, insecure)
+
+  def dbUrl_=(url: String): Self = selfCopy(url, timeout, insecure)
+
+  def insecure_=(b: Boolean): Self = selfCopy(dbUrl, timeout, b)
 
   protected type Self <: DBCommand
 
-  protected def selfCopy: (String, Duration) => Self
+  protected def selfCopy: (String, Duration, Boolean) => Self
 }
 
 object DBCommand {
   val defaultTimeout: Duration = 1.minute
+  val defaultInsecure: Boolean = false
 }
 
 case class DBInit(
   override val dbUrl: String = null,
   override val timeout: Duration = DBCommand.defaultTimeout,
+  override val insecure: Boolean = DBCommand.defaultInsecure,
   force: Boolean = false,
   skip: Boolean = false
 ) extends DBCommand {
   protected override type Self = DBInit
-  protected override val selfCopy: (String, Duration) => DBInit = copy(_, _)
+  protected override val selfCopy: (String, Duration, Boolean) => DBInit = copy(_, _, _)
 }
 
 case class DBUpgrade(
   override val dbUrl: String = null,
-  override val timeout: Duration = DBCommand.defaultTimeout
+  override val timeout: Duration = DBCommand.defaultTimeout,
+  override val insecure: Boolean = DBCommand.defaultInsecure
 ) extends DBCommand {
   protected override type Self = DBUpgrade
-  protected override val selfCopy: (String, Duration) => DBUpgrade = copy
+  protected override val selfCopy: (String, Duration, Boolean) => DBUpgrade = copy
 }

--- a/persistence/src/main/scala/za/co/absa/spline/persistence/ArangoConnectionURL.scala
+++ b/persistence/src/main/scala/za/co/absa/spline/persistence/ArangoConnectionURL.scala
@@ -38,11 +38,11 @@ case class ArangoConnectionURL(scheme: String, user: Option[String], password: O
 object ArangoConnectionURL {
 
   private val ArangoDbScheme = "arangodb"
-  private val ArangoSecureDbScheme = "arangodb+ssl"
+  private val ArangoSecureDbScheme = "arangodbs"
   private val DefaultPort = 8529
 
   private val arangoConnectionUrlRegex = {
-    val scheme = s"$ArangoDbScheme|$ArangoSecureDbScheme"
+    val scheme = s"^($ArangoDbScheme|$ArangoSecureDbScheme)"
     val user = "([^@:]+)"
     val password = "(.+)"
     val host = "([^@:]+)"

--- a/persistence/src/main/scala/za/co/absa/spline/persistence/ArangoConnectionURL.scala
+++ b/persistence/src/main/scala/za/co/absa/spline/persistence/ArangoConnectionURL.scala
@@ -37,8 +37,8 @@ case class ArangoConnectionURL(scheme: String, user: Option[String], password: O
 
 object ArangoConnectionURL {
 
-  private val ArangoDbScheme = "arangodb"
-  private val ArangoSecureDbScheme = "arangodbs"
+  val ArangoDbScheme = "arangodb"
+  val ArangoSecureDbScheme = "arangodbs"
   private val DefaultPort = 8529
 
   private val arangoConnectionUrlRegex = {

--- a/persistence/src/main/scala/za/co/absa/spline/persistence/ArangoDatabaseFacade.scala
+++ b/persistence/src/main/scala/za/co/absa/spline/persistence/ArangoDatabaseFacade.scala
@@ -21,13 +21,38 @@ import com.arangodb.async.{ArangoDBAsync, ArangoDatabaseAsync}
 import org.springframework.beans.factory.DisposableBean
 import za.co.absa.commons.lang.OptionImplicits.AnyWrapper
 
+import javax.net.ssl._
+import java.security.SecureRandom
+import java.security.cert.X509Certificate
+
 class ArangoDatabaseFacade(connectionURL: ArangoConnectionURL) extends DisposableBean {
 
   private val ArangoConnectionURL(_, maybeUser, maybePassword, host, port, dbName) = connectionURL
 
+  private val isSecure = connectionURL.isSecure
+
+  private def createSslContext: SSLContext = {
+    val sslContext = SSLContext.getInstance("SSL")
+    sslContext.init(null, Array(TrustAll), new SecureRandom())
+    sslContext
+  }
+
+  // Bypasses both client and server validation.
+  private object TrustAll extends X509TrustManager {
+    val getAcceptedIssuers = null
+    def checkClientTrusted(x509Certificates: Array[X509Certificate], s: String) = {}
+    def checkServerTrusted(x509Certificates: Array[X509Certificate], s: String) = {}
+  }
+
+  // Verifies all host names by simply returning true.
+  private object VerifiesAllHostNames extends HostnameVerifier {
+    def verify(s: String, sslSession: SSLSession) = true
+  }
+
   private val arango: ArangoDBAsync = new ArangoDBAsync.Builder()
     .registerModule(new VPackScalaModule)
-    .useSsl(connectionURL.isSecure)
+    .useSsl(isSecure)
+    .optionally(_.sslContext(_: SSLContext), Option(isSecure).map(_ => createSslContext))
     .host(host, port)
     .optionally(_.user(_: String), maybeUser)
     .optionally(_.password(_: String), maybePassword)

--- a/persistence/src/main/scala/za/co/absa/spline/persistence/ArangoDatabaseFacade.scala
+++ b/persistence/src/main/scala/za/co/absa/spline/persistence/ArangoDatabaseFacade.scala
@@ -23,10 +23,11 @@ import za.co.absa.commons.lang.OptionImplicits.AnyWrapper
 
 class ArangoDatabaseFacade(connectionURL: ArangoConnectionURL) extends DisposableBean {
 
-  private val ArangoConnectionURL(maybeUser, maybePassword, host, port, dbName) = connectionURL
+  private val ArangoConnectionURL(_, maybeUser, maybePassword, host, port, dbName) = connectionURL
 
   private val arango: ArangoDBAsync = new ArangoDBAsync.Builder()
     .registerModule(new VPackScalaModule)
+    .useSsl(connectionURL.isSecure)
     .host(host, port)
     .optionally(_.user(_: String), maybeUser)
     .optionally(_.password(_: String), maybePassword)

--- a/persistence/src/test/scala/za/co/absa/spline/persistence/ArangoConnectionURLSpec.scala
+++ b/persistence/src/test/scala/za/co/absa/spline/persistence/ArangoConnectionURLSpec.scala
@@ -16,6 +16,8 @@
 
 package za.co.absa.spline.persistence
 
+import ArangoConnectionURL.{ArangoDbScheme, ArangoSecureDbScheme}
+
 import java.net.MalformedURLException
 
 import org.scalatest.flatspec.AnyFlatSpec
@@ -30,6 +32,11 @@ class ArangoConnectionURLSpec extends AnyFlatSpec with Matchers {
     url.host shouldEqual "my.host.com"
     url.port shouldEqual 8529
     url.dbName shouldEqual "foo-bar_db"
+  }
+
+  it should "parse ArangoDB secure connection URL" in {
+    val url = ArangoConnectionURL("arangodbs://my.host.com/foo-bar_db")
+    url.scheme shouldEqual ArangoSecureDbScheme
   }
 
   it should "parse ArangoDB connection URL with port number" in {
@@ -66,12 +73,12 @@ class ArangoConnectionURLSpec extends AnyFlatSpec with Matchers {
   behavior of "toURI()"
 
   it should "compose equivalent representation of the input" in {
-    ArangoConnectionURL(None, None, "host", 42, "test").toURI.toString shouldEqual "arangodb://host:42/test"
-    ArangoConnectionURL(Some("alice"), None, "host", 42, "test").toURI.toString shouldEqual "arangodb://alice@host:42/test"
+    ArangoConnectionURL(ArangoDbScheme, None, None, "host", 42, "test").toURI.toString shouldEqual "arangodb://host:42/test"
+    ArangoConnectionURL(ArangoDbScheme, Some("alice"), None, "host", 42, "test").toURI.toString shouldEqual "arangodb://alice@host:42/test"
   }
 
   it should "hide user password" in {
-    ArangoConnectionURL(Some("bob"), Some("secret"), "host", 42, "test").toURI.toString shouldEqual "arangodb://bob:*****@host:42/test"
+    ArangoConnectionURL(ArangoDbScheme, Some("bob"), Some("secret"), "host", 42, "test").toURI.toString shouldEqual "arangodb://bob:*****@host:42/test"
   }
 
 }


### PR DESCRIPTION
See [here](https://github.com/AbsaOSS/spline/issues/620) for the feature request.

A new schema `arangodbs` is added.  The SSL implementation is unsecure - the server certificate is not validated. Because of this, the user must explicitly give a `-k` `--insecure` switch to allow for an SSL connection.

Tests are (not) yet implemented - I might have some time later today or in the coming days; but you have time too team, even better maybe.

Thanks,

cc @wajda @patrickdehoon