### PR TITLE
spline #823 `POST /producer/execution-plans` should not replace execu…

### DIFF
--- a/producer-rest-core/src/main/scala/za/co/absa/spline/producer/rest/controller/ExecutionPlansController.scala
+++ b/producer-rest-core/src/main/scala/za/co/absa/spline/producer/rest/controller/ExecutionPlansController.scala
@@ -43,12 +43,6 @@ class ExecutionPlansController @Autowired()(
       """
         Saves an Execution Plan and returns its new UUID.
 
-        In most cases, if `id` is provided by the client it will be used and returned
-        to the client. However, in the future Spline server could recognize duplicated
-        execution plans, in which case the method will return UUID of already existing
-        execution plan. In all the future interactions with the Spline API, the client
-        must use this UUID instead of the original UUID to refer the given Execution Plan.
-
         Payload format:
 
         {


### PR DESCRIPTION
…tion plan ID

Remove corresponding paragraph from the REST documentation

Fixes #823