### PR TITLE
spline #843 Consumer REST: Add "dataSourceName" field to the "WriteEventInfo" entity

### DIFF
--- a/consumer-services/src/main/scala/za/co/absa/spline/consumer/service/model/WriteEventInfo.scala
+++ b/consumer-services/src/main/scala/za/co/absa/spline/consumer/service/model/WriteEventInfo.scala
@@ -31,14 +31,16 @@ case class WriteEventInfo
   applicationId: String,
   @ApiModelProperty(value = "When the execution was triggered")
   timestamp: Long,
-  @ApiModelProperty(value = "Output file uri")
+  @ApiModelProperty(value = "Output data source name")
+  dataSourceName: String,
+  @ApiModelProperty(value = "Output data source URI")
   dataSourceUri: String,
-  @ApiModelProperty(value = "Type of the output file")
+  @ApiModelProperty(value = "Output data source (or data) type")
   dataSourceType: String,
   @ApiModelProperty(value = "Write mode - (true=Append; false=Override)")
   append: Boolean
 ) {
-  def this() = this(null, null, null, null, null, 0, null, null, false)
+  def this() = this(null, null, null, null, null, 0, null, null, null, false)
 }
 
 object WriteEventInfo {

--- a/consumer-services/src/main/scala/za/co/absa/spline/consumer/service/repo/DataSourceRepositoryImpl.scala
+++ b/consumer-services/src/main/scala/za/co/absa/spline/consumer/service/repo/DataSourceRepositoryImpl.scala
@@ -81,6 +81,7 @@ class DataSourceRepositoryImpl @Autowired()(db: ArangoDatabaseAsync) extends Dat
         |        "applicationName"  : lwe.execPlanDetails.applicationName,
         |        "applicationId"    : lwe.extra.appId,
         |        "timestamp"        : lwe.timestamp || 0,
+        |        "dataSourceName"   : REGEX_MATCHES(ds.uri, "([^/]+)/*$")[1],
         |        "dataSourceUri"    : ds.uri,
         |        "dataSourceType"   : lwe.execPlanDetails.dataSourceType,
         |        "append"           : lwe.execPlanDetails.append || false

--- a/consumer-services/src/main/scala/za/co/absa/spline/consumer/service/repo/ExecutionEventRepositoryImpl.scala
+++ b/consumer-services/src/main/scala/za/co/absa/spline/consumer/service/repo/ExecutionEventRepositoryImpl.scala
@@ -104,6 +104,7 @@ class ExecutionEventRepositoryImpl @Autowired()(db: ArangoDatabaseAsync) extends
         |        "applicationName"  : ee.execPlanDetails.applicationName,
         |        "applicationId"    : ee.extra.appId,
         |        "timestamp"        : ee.timestamp,
+        |        "dataSourceName"   : REGEX_MATCHES(ee.execPlanDetails.dataSourceUri, "([^/]+)/*$")[1],
         |        "dataSourceUri"    : ee.execPlanDetails.dataSourceUri,
         |        "dataSourceType"   : ee.execPlanDetails.dataSourceType,
         |        "append"           : ee.execPlanDetails.append


### PR DESCRIPTION
The field is derived from the URI as the last meaningful part of the URI