### PR TITLE
spline #850 Upgrade ArangoDB Java Driver and remove deprecated workaround for VstConnectionAsync ClassCastException

### DIFF
--- a/persistence/pom.xml
+++ b/persistence/pom.xml
@@ -62,7 +62,7 @@
         <dependency>
             <groupId>com.arangodb</groupId>
             <artifactId>arangodb-java-driver</artifactId>
-            <version>6.9.0</version>
+            <version>6.9.1</version>
         </dependency>
         <dependency>
             <groupId>com.arangodb</groupId>


### PR DESCRIPTION
~This PR waits for the arangodb/arangodb-java-driver#378 to be merged and the new driver version to be released.~
The new driver version 6.9.1 is out. We can proceed with the PR.