### PR TITLE
spline #878 Docker image for Admin CLI

### DIFF
--- a/admin/Dockerfile
+++ b/admin/Dockerfile
@@ -13,10 +13,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# Run image using:
+# $> docker run --rm -it \
+# -e ARANGODB_URL=arangodb://User:Password@ArangoURL:8529/YOUR-Spline-DB-Name \
+# absaoss/spline-admin:latest
 
-FROM adoptopenjdk/openjdk11:jdk-11.0.10_9-alpine-slim
+ARG DOCKER_BASE_ARTIFACT=adoptopenjdk/openjdk11
+ARG DOCKER_BASE_TAG=jdk-11.0.10_9-alpine-slim
 
-ARG version
+FROM $DOCKER_BASE_ARTIFACT:$DOCKER_BASE_TAG
+
+ARG VERSION
 
 LABEL \
     vendor="ABSA" \
@@ -24,7 +31,7 @@ LABEL \
     license="Apache License, version 2.0" \
     name="Spline Admin Tool"
 
-COPY target/admin-$version.jar ./admin.jar
+COPY target/admin-$VERSION.jar ./admin.jar
 
-ENTRYPOINT ["java", "-jar", "admin.jar"]
+ENTRYPOINT ["java", "-jar", "admin.jar" ]
 CMD ["--help"]

--- a/admin/Dockerfile
+++ b/admin/Dockerfile
@@ -14,9 +14,7 @@
 # limitations under the License.
 #
 # Run image using:
-# $> docker run --rm -it \
-# -e ARANGODB_URL=arangodb://User:Password@ArangoURL:8529/YOUR-Spline-DB-Name \
-# absaoss/spline-admin:latest
+# $> docker run --rm -it absaoss/spline-admin:latest
 
 ARG DOCKER_BASE_ARTIFACT=adoptopenjdk/openjdk11
 ARG DOCKER_BASE_TAG=jdk-11.0.10_9-alpine-slim
@@ -33,5 +31,5 @@ LABEL \
 
 COPY target/admin-$VERSION.jar ./admin.jar
 
-ENTRYPOINT ["java", "-jar", "admin.jar" ]
+ENTRYPOINT ["java", "-jar", "admin.jar"]
 CMD ["--help"]

--- a/admin/Dockerfile
+++ b/admin/Dockerfile
@@ -14,16 +14,17 @@
 # limitations under the License.
 #
 
-FROM tomcat:9.0.45-jdk11-corretto
+FROM adoptopenjdk/openjdk11:jdk-11.0.10_9-alpine-slim
+
+ARG version
 
 LABEL \
     vendor="ABSA" \
-    copyright="2019 ABSA Group Limited" \
+    copyright="2021 ABSA Group Limited" \
     license="Apache License, version 2.0" \
-    name="Spline REST Gateway Server"
+    name="Spline Admin Tool"
 
-EXPOSE 8080
-EXPOSE 8009
+COPY target/admin-$version.jar ./admin.jar
 
-RUN rm -rf /usr/local/tomcat/webapps/*
-COPY target/*.war /usr/local/tomcat/webapps/ROOT.war
+ENTRYPOINT ["java", "-jar", "admin.jar"]
+CMD ["--help"]

--- a/admin/Dockerfile
+++ b/admin/Dockerfile
@@ -13,13 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
 # Run image using:
 # $> docker run --rm -it absaoss/spline-admin:latest
 
-ARG DOCKER_BASE_ARTIFACT=adoptopenjdk/openjdk11
-ARG DOCKER_BASE_TAG=jdk-11.0.10_9-alpine-slim
+ARG DOCKER_BASE_IMAGE_PREFIX=
 
-FROM $DOCKER_BASE_ARTIFACT:$DOCKER_BASE_TAG
+FROM "$DOCKER_BASE_IMAGE_PREFIX"adoptopenjdk/openjdk11:jdk-11.0.10_9-alpine-slim
 
 ARG VERSION
 

--- a/admin/pom.xml
+++ b/admin/pom.xml
@@ -30,6 +30,8 @@
 
     <properties>
         <dockerfile.repositoryUrl><!-- defined externally --></dockerfile.repositoryUrl>
+        <dockerfile.repository>${dockerfile.repositoryUrl}/spline-admin</dockerfile.repository>
+        <dockerfile.tag>${project.version}</dockerfile.tag>
     </properties>
 
     <dependencies>
@@ -98,9 +100,12 @@
                 <configuration>
                     <skip>false</skip>
                     <buildArgs>
-                        <version>${project.version}</version>
+                        <DOCKER_BASE_ARTIFACT>${dockerfile.base.artifact}</DOCKER_BASE_ARTIFACT>
+                        <DOCKER_BASE_TAG>${dockerfile.base.tag}</DOCKER_BASE_TAG>
+                        <VERSION>${project.version}</VERSION>
                     </buildArgs>
-                    <repository>${dockerfile.repositoryUrl}/spline-admin</repository>
+                    <repository>${dockerfile.repository}</repository>
+                    <tag>${dockerfile.tag}</tag>
                 </configuration>
             </plugin>
         </plugins>

--- a/admin/pom.xml
+++ b/admin/pom.xml
@@ -28,6 +28,10 @@
     <artifactId>admin</artifactId>
     <packaging>jar</packaging>
 
+    <properties>
+        <dockerfile.repositoryUrl><!-- defined externally --></dockerfile.repositoryUrl>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>za.co.absa.spline</groupId>
@@ -87,6 +91,17 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>com.spotify</groupId>
+                <artifactId>dockerfile-maven-plugin</artifactId>
+                <configuration>
+                    <skip>false</skip>
+                    <buildArgs>
+                        <version>${project.version}</version>
+                    </buildArgs>
+                    <repository>${dockerfile.repositoryUrl}/spline-admin</repository>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/admin/pom.xml
+++ b/admin/pom.xml
@@ -29,9 +29,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <dockerfile.repositoryUrl><!-- defined externally --></dockerfile.repositoryUrl>
-        <dockerfile.repository>${dockerfile.repositoryUrl}/spline-admin</dockerfile.repository>
-        <dockerfile.tag>${project.version}</dockerfile.tag>
+        <dockerfile.imageName>spline-admin</dockerfile.imageName>
     </properties>
 
     <dependencies>
@@ -100,12 +98,8 @@
                 <configuration>
                     <skip>false</skip>
                     <buildArgs>
-                        <DOCKER_BASE_ARTIFACT>${dockerfile.base.artifact}</DOCKER_BASE_ARTIFACT>
-                        <DOCKER_BASE_TAG>${dockerfile.base.tag}</DOCKER_BASE_TAG>
                         <VERSION>${project.version}</VERSION>
                     </buildArgs>
-                    <repository>${dockerfile.repository}</repository>
-                    <tag>${dockerfile.tag}</tag>
                 </configuration>
             </plugin>
         </plugins>

--- a/build/package-pom/pom.xml
+++ b/build/package-pom/pom.xml
@@ -52,6 +52,19 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+        <dockerfile.versionTagPrefix><!-- defined externally --></dockerfile.versionTagPrefix>
+        <dockerfile.versionTagName>${dockerfile.versionTagPrefix}${project.version}</dockerfile.versionTagName>
+
+        <dockerfile.latestTagPrefix><!-- defined externally --></dockerfile.latestTagPrefix>
+        <dockerfile.latestTagName>${dockerfile.latestTagPrefix}latest</dockerfile.latestTagName>
+
+        <dockerfile.imageName><!-- defined in submodules --></dockerfile.imageName>
+        <!-- Either ${dockerfile.repositoryUrl} or ${dockerfile.repositoryUrl} is required to be explicitly provided in the `mvn` command -->
+        <dockerfile.repositoryUrl><!-- defined externally --></dockerfile.repositoryUrl>
+        <dockerfile.repository>${dockerfile.repositoryUrl}/${dockerfile.imageName}</dockerfile.repository>
+        <!-- [Optional] The prefix for the base images in Dockerfile (mainly used in custom CI/CD pipelines to pull images from alternative locations) -->
+        <dockerfile.baseImagePrefix><!-- defined externally --></dockerfile.baseImagePrefix>
     </properties>
 
     <developers>
@@ -194,7 +207,7 @@
                                     <goal>push</goal>
                                 </goals>
                                 <configuration>
-                                    <tag>${project.version}</tag>
+                                    <tag>${dockerfile.versionTagName}</tag>
                                 </configuration>
                             </execution>
                             <execution>
@@ -204,14 +217,17 @@
                                     <goal>push</goal>
                                 </goals>
                                 <configuration>
-                                    <tag>latest</tag>
+                                    <tag>${dockerfile.latestTagName}</tag>
                                 </configuration>
                             </execution>
                         </executions>
                         <configuration>
                             <skip>true</skip>
                             <!-- Dockerfile plugin requires <repository> to be non-empty even if <skip> is true -->
-                            <repository>placeholder/DO_NOT_REMOVE</repository>
+                            <repository>${dockerfile.repository}</repository>
+                            <buildArgs combine.children="append">
+                                <DOCKER_BASE_IMAGE_PREFIX>${dockerfile.baseImagePrefix}</DOCKER_BASE_IMAGE_PREFIX>
+                            </buildArgs>
                             <useMavenSettingsForAuth>true</useMavenSettingsForAuth>
                         </configuration>
                     </plugin>

--- a/build/package-pom/pom.xml
+++ b/build/package-pom/pom.xml
@@ -144,6 +144,13 @@
                 <plugins>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-deploy-plugin</artifactId>
+                        <configuration>
+                            <skip>false</skip>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
                         <executions>
                             <execution>
@@ -196,6 +203,13 @@
                             <autoDropAfterRelease>true</autoDropAfterRelease>
                         </configuration>
                     </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>docker</id>
+            <build>
+                <plugins>
                     <plugin>
                         <groupId>com.spotify</groupId>
                         <artifactId>dockerfile-maven-plugin</artifactId>
@@ -237,6 +251,15 @@
     </profiles>
 
     <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
         <pluginManagement>
             <plugins>
                 <plugin>

--- a/build/package-pom/pom.xml
+++ b/build/package-pom/pom.xml
@@ -62,9 +62,15 @@
         <dockerfile.latestTagName>${dockerfile.latestTagPrefix}latest${dockerfile.latestTagSuffix}</dockerfile.latestTagName>
 
         <dockerfile.imageName><!-- defined in submodules --></dockerfile.imageName>
-        <!-- Either ${dockerfile.repositoryUrl} or ${dockerfile.repositoryUrl} is required to be explicitly provided in the `mvn` command -->
+        <!--
+            One of `dockerfile.repositoryUrl`, `dockerfile.repositoryPrefix` or `dockerfile.repository`
+            properties is required to be explicitly provided in the `mvn` command,
+            so that the resulted `dockerfile.repository` property has a correct value.
+        -->
         <dockerfile.repositoryUrl><!-- defined externally --></dockerfile.repositoryUrl>
-        <dockerfile.repository>${dockerfile.repositoryUrl}/${dockerfile.imageName}</dockerfile.repository>
+        <dockerfile.repositoryPrefix>${dockerfile.repositoryUrl}/</dockerfile.repositoryPrefix>
+        <dockerfile.repositorySuffix><!-- defined externally --></dockerfile.repositorySuffix>
+        <dockerfile.repository>${dockerfile.repositoryPrefix}${dockerfile.imageName}${dockerfile.repositorySuffix}</dockerfile.repository>
         <!-- [Optional] The prefix for the base images in Dockerfile (mainly used in custom CI/CD pipelines to pull images from alternative locations) -->
         <dockerfile.baseImagePrefix><!-- defined externally --></dockerfile.baseImagePrefix>
     </properties>

--- a/build/package-pom/pom.xml
+++ b/build/package-pom/pom.xml
@@ -54,10 +54,12 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <dockerfile.versionTagPrefix><!-- defined externally --></dockerfile.versionTagPrefix>
-        <dockerfile.versionTagName>${dockerfile.versionTagPrefix}${project.version}</dockerfile.versionTagName>
+        <dockerfile.versionTagSuffix><!-- defined externally --></dockerfile.versionTagSuffix>
+        <dockerfile.versionTagName>${dockerfile.versionTagPrefix}${project.version}${dockerfile.versionTagSuffix}</dockerfile.versionTagName>
 
         <dockerfile.latestTagPrefix><!-- defined externally --></dockerfile.latestTagPrefix>
-        <dockerfile.latestTagName>${dockerfile.latestTagPrefix}latest</dockerfile.latestTagName>
+        <dockerfile.latestTagSuffix><!-- defined externally --></dockerfile.latestTagSuffix>
+        <dockerfile.latestTagName>${dockerfile.latestTagPrefix}latest${dockerfile.latestTagSuffix}</dockerfile.latestTagName>
 
         <dockerfile.imageName><!-- defined in submodules --></dockerfile.imageName>
         <!-- Either ${dockerfile.repositoryUrl} or ${dockerfile.repositoryUrl} is required to be explicitly provided in the `mvn` command -->

--- a/kafka-gateway/Dockerfile
+++ b/kafka-gateway/Dockerfile
@@ -1,0 +1,31 @@
+#
+# Copyright 2019 ABSA Group Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+ARG DOCKER_BASE_IMAGE_PREFIX=
+
+FROM "$DOCKER_BASE_IMAGE_PREFIX"tomcat:9.0.45-jdk11-corretto
+
+LABEL \
+    vendor="ABSA" \
+    copyright="2021 ABSA Group Limited" \
+    license="Apache License, version 2.0" \
+    name="Spline Kafka Gateway Server"
+
+EXPOSE 8080
+EXPOSE 8009
+
+RUN rm -rf /usr/local/tomcat/webapps/*
+COPY target/*.war /usr/local/tomcat/webapps/ROOT.war

--- a/kafka-gateway/pom.xml
+++ b/kafka-gateway/pom.xml
@@ -30,6 +30,10 @@
     <artifactId>kafka-gateway</artifactId>
     <packaging>war</packaging>
 
+    <properties>
+        <dockerfile.imageName>spline-kafka-server</dockerfile.imageName>
+    </properties>
+
     <dependencies>
 
         <dependency>
@@ -69,5 +73,17 @@
             <artifactId>finatra-jackson_${scala.compat.version}</artifactId>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.spotify</groupId>
+                <artifactId>dockerfile-maven-plugin</artifactId>
+                <configuration>
+                    <skip>false</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,19 @@
         <module>admin</module>
     </modules>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <version>2.8.2</version>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
     <profiles>
         <profile>
             <id>release</id>

--- a/rest-gateway/Dockerfile
+++ b/rest-gateway/Dockerfile
@@ -14,7 +14,9 @@
 # limitations under the License.
 #
 
-FROM tomcat:9.0.45-jdk11-corretto
+ARG DOCKER_BASE_IMAGE_PREFIX=
+
+FROM "$DOCKER_BASE_IMAGE_PREFIX"tomcat:9.0.45-jdk11-corretto
 
 LABEL \
     vendor="ABSA" \

--- a/rest-gateway/pom.xml
+++ b/rest-gateway/pom.xml
@@ -32,7 +32,7 @@
         <swagger.docs.path>${project.build.directory}/api/docs</swagger.docs.path>
         <timestamp>${maven.build.timestamp}</timestamp>
         <maven.build.timestamp.format>yyyy-MM-dd'T'HH:mm:ssX</maven.build.timestamp.format>
-        <dockerfile.repositoryUrl><!-- defined externally --></dockerfile.repositoryUrl>
+        <dockerfile.imageName>spline-rest-server</dockerfile.imageName>
     </properties>
 
     <dependencies>
@@ -164,7 +164,6 @@
                 <artifactId>dockerfile-maven-plugin</artifactId>
                 <configuration>
                     <skip>false</skip>
-                    <repository>${dockerfile.repositoryUrl}/spline-rest-server</repository>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
- Added a docker wrapper for the Admin CLI
- Added a docker wrapper for the Kafka Gateway
- Updated Tomcat and Java for the Gateway container
- Split _deploy_ and _docker_ Maven profiles
- Disable `deploy-maven-profile` by default to allow for executing _deploy_ phase for other deployment profiles (e.g. _docker_) without necessity to deploy standard Maven artifacts as well.
- Introduce the following properties (configured as JVM props in the Maven command line):
  - `dockerfile.repository` - The repository to name the built image (see https://github.com/spotify/dockerfile-maven/blob/master/docs/usage.md). Default value is `${dockerfile.repositoryUrl}/${dockerfile.imageName}`
  - `dockerfile.repositoryPrefix` - prefix to the default ${dockerfile.repository} value. Default value is `${dockerfile.repositoryUrl}/`.
  - `dockerfile.repositorySuffix` - suffix to the default ${dockerfile.repository} value. Default value is empty.
  - `dockerfile.repositoryUrl` - repository location - a prefix to the default ${dockerfile.repositoryPrefix} value. Default value is empty, and is required to be provided unless `dockerfile.repository` or `dockerfile.repositoryPrefix` is overridden.
  - `dockerfile.baseImagePrefix` - a prefix string used to prefix all base artifacts that appear after the `FROM` keywords in _Dockerfiles_. It's used to customize image source location, mainly for the purpose of custom CI/CD pipelines. Default value is empty.
  - `dockerfile.versionTagName` - the name of the _version_ tag. Default value is`${dockerfile.versionTagPrefix}${project.version}${dockerfile.versionTagSuffix}`
  - `dockerfile.versionTagPrefix` - the prefix for above. Default value is empty.
  - `dockerfile.versionTagSuffix` - the suffix for above. Default value is empty.
  - `dockerfile.latestTagName` - the name of the _version_ tag. Default value is`${dockerfile.latestTagPrefix}latest${dockerfile.latestTagSuffix}`
  - `dockerfile.latestTagPrefix` - the prefix for above. Default value is empty.
  - `dockerfile.latestTagSuffix` - the suffix for above. Default value is empty.
  
### Usage examples:

#### To build and tag the images (no push):
```shell
# `dockerfile.repositoryUrl` must be provided, even though there is no intention to push the images there - this is a Spotify plugin specifics.
mvn install -P docker -Ddockerfile.repositoryUrl=absaoss
```

#### To build, tag and push:
```shell
mvn deploy -P docker -Ddockerfile.repositoryUrl=docker.io/absaoss
```

#### To build and tag with custom prefix and suffix:
```shell
mvn install -P docker \
  -Ddockerfile.repositoryUrl=absaoss \
  -Dbuildfile.versionTagSuffix=+5e8d7f6 \
  -Dbuildfile.latestTagPrefix=dev
```
That will produce two tags: `:1.2.3-SNAPSHOT+5e8d7f6` and `:dev-latest`

#### To pull base images from a custom location / with a custom prefix:
```shell
mvn install -P docker \
  -Ddockerfile.repositoryUrl=absaoss \
  -Dbuildfile.baseImagePrefix=my.ecr.aws.example.org/foo/bar/my-
```
That will pull `my.ecr.aws.example.org/foo/bar/my-adoptopenjdk/openjdk11:jdk-11.0.10_9-alpine-slim` instead of `adoptopenjdk/openjdk11:jdk-11.0.10_9-alpine-slim`