### PR TITLE
added ARG for base_image and changed docker-entrypoint

### DIFF
--- a/admin/Dockerfile
+++ b/admin/Dockerfile
@@ -31,10 +31,7 @@ LABEL \
     license="Apache License, version 2.0" \
     name="Spline Admin Tool"
 
-ENV ADMIN_COMMAND="db-init"
-ENV ARANGODB_URL="arangodb://localhost:8529/spline"
-ENV EXTRA_ARGS="-s"
-
 COPY target/admin-$VERSION.jar ./admin.jar
 
-ENTRYPOINT java -jar admin.jar $ADMIN_COMMAND $ARANGODB_URL $EXTRA_ARGS
+ENTRYPOINT ["java", "-jar", "admin.jar" ]
+CMD ["--help"]

--- a/admin/Dockerfile
+++ b/admin/Dockerfile
@@ -13,10 +13,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# Run image using:
+# $> docker run --rm -it \
+# -e ARANGODB_URL=arangodb://User:Password@ArangoURL:8529/YOUR-Spline-DB-Name \
+# absaoss/spline-admin:latest
 
-FROM adoptopenjdk/openjdk11:jdk-11.0.10_9-alpine-slim
+ARG DOCKER_BASE_ARTIFACT=adoptopenjdk/openjdk11
+ARG DOCKER_BASE_TAG=jdk-11.0.10_9-alpine-slim
 
-ARG version
+FROM $DOCKER_BASE_ARTIFACT:$DOCKER_BASE_TAG
+
+ARG VERSION
 
 LABEL \
     vendor="ABSA" \
@@ -24,7 +31,10 @@ LABEL \
     license="Apache License, version 2.0" \
     name="Spline Admin Tool"
 
-COPY target/admin-$version.jar ./admin.jar
+ENV ADMIN_COMMAND="db-init"
+ENV ARANGODB_URL="arangodb://localhost:8529/spline"
+ENV EXTRA_ARGS="-s"
 
-ENTRYPOINT ["java", "-jar", "admin.jar"]
-CMD ["--help"]
+COPY target/admin-$VERSION.jar ./admin.jar
+
+ENTRYPOINT java -jar admin.jar $ADMIN_COMMAND $ARANGODB_URL $EXTRA_ARGS

--- a/admin/pom.xml
+++ b/admin/pom.xml
@@ -29,7 +29,8 @@
     <packaging>jar</packaging>
 
     <properties>
-        <dockerfile.spline-admin.repository>absaoss/spline-admin</dockerfile.spline-admin.repository>
+        <dockerfile.repositoryUrl><!-- defined externally --></dockerfile.repositoryUrl>
+        <dockerfile.spline-admin.repository>${dockerfile.repositoryUrl}/spline-admin</dockerfile.spline-admin.repository>
         <dockerfile.tag>${project.version}</dockerfile.tag>
     </properties>
 

--- a/admin/pom.xml
+++ b/admin/pom.xml
@@ -30,7 +30,7 @@
 
     <properties>
         <dockerfile.repositoryUrl><!-- defined externally --></dockerfile.repositoryUrl>
-        <dockerfile.spline-admin.repository>${dockerfile.repositoryUrl}/spline-admin</dockerfile.spline-admin.repository>
+        <dockerfile.repository>${dockerfile.repositoryUrl}/spline-admin</dockerfile.repository>
         <dockerfile.tag>${project.version}</dockerfile.tag>
     </properties>
 
@@ -104,7 +104,7 @@
                         <DOCKER_BASE_TAG>${dockerfile.base.tag}</DOCKER_BASE_TAG>
                         <VERSION>${project.version}</VERSION>
                     </buildArgs>
-                    <repository>${dockerfile.spline-admin.repository}</repository>
+                    <repository>${dockerfile.repository}</repository>
                     <tag>${dockerfile.tag}</tag>
                 </configuration>
             </plugin>

--- a/admin/pom.xml
+++ b/admin/pom.xml
@@ -29,7 +29,8 @@
     <packaging>jar</packaging>
 
     <properties>
-        <dockerfile.repositoryUrl><!-- defined externally --></dockerfile.repositoryUrl>
+        <dockerfile.spline-admin.repository>absaoss/spline-admin</dockerfile.spline-admin.repository>
+        <dockerfile.tag>${project.version}</dockerfile.tag>
     </properties>
 
     <dependencies>
@@ -98,9 +99,12 @@
                 <configuration>
                     <skip>false</skip>
                     <buildArgs>
-                        <version>${project.version}</version>
+                        <DOCKER_BASE_ARTIFACT>${dockerfile.base.artifact}</DOCKER_BASE_ARTIFACT>
+                        <DOCKER_BASE_TAG>${dockerfile.base.tag}</DOCKER_BASE_TAG>
+                        <VERSION>${project.version}</VERSION>
                     </buildArgs>
-                    <repository>${dockerfile.repositoryUrl}/spline-admin</repository>
+                    <repository>${dockerfile.spline-admin.repository}</repository>
+                    <tag>${dockerfile.tag}</tag>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
example of using NON-default base image:

`mvn dockerfile:build -Ddockerfile.tag=test -D**dockerfile.base.artifact**=openjdk -Ddockerfile.base.tag=11.0-jre-buster`