### PR TITLE
spline #898 Consumer API: execution plan name is `null`

### DIFF
--- a/consumer-services/src/main/scala/za/co/absa/spline/consumer/service/repo/ExecutionPlanRepositoryImpl.scala
+++ b/consumer-services/src/main/scala/za/co/absa/spline/consumer/service/repo/ExecutionPlanRepositoryImpl.scala
@@ -91,6 +91,7 @@ class ExecutionPlanRepositoryImpl @Autowired()(db: ArangoDatabaseAsync) extends 
         |        "_id"       : execPlan._key,
         |        "systemInfo": execPlan.systemInfo,
         |        "agentInfo" : execPlan.agentInfo,
+        |        "name"      : execPlan.name || execPlan._key,
         |        "extra"     : MERGE(
         |                         execPlan.extra,
         |                         { attributes },


### PR DESCRIPTION
fixes #898 