### PR TITLE
spline #909 replace custom finatra fork with standard deserializer

### DIFF
--- a/build/parent-pom/pom.xml
+++ b/build/parent-pom/pom.xml
@@ -261,13 +261,8 @@
                 <version>${jackson.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.github.cerveada</groupId>
+                <groupId>com.twitter</groupId>
                 <artifactId>finatra-jackson_${scala.compat.version}</artifactId>
-                <version>${finatra.jackson.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.github.cerveada</groupId>
-                <artifactId>finatra-json-annotations_${scala.compat.version}</artifactId>
                 <version>${finatra.jackson.version}</version>
             </dependency>
 
@@ -453,16 +448,5 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
-
-    <repositories>
-        <repository>
-            <id>twitter-finatra-jackson-mvn-repo</id>
-            <url>https://raw.githubusercontent.com/cerveada/finatra/mvn-repo/</url>
-            <snapshots>
-                <enabled>true</enabled>
-                <updatePolicy>always</updatePolicy>
-            </snapshots>
-        </repository>
-    </repositories>
 
 </project>

--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -83,13 +83,8 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>com.github.cerveada</groupId>
+            <groupId>com.twitter</groupId>
             <artifactId>finatra-jackson_${scala.compat.version}</artifactId>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>com.github.cerveada</groupId>
-            <artifactId>finatra-json-annotations_${scala.compat.version}</artifactId>
             <optional>true</optional>
         </dependency>
         <dependency>

--- a/commons/src/main/scala/za/co/absa/spline/common/webmvc/jackson/NullAcceptingDeserializer.scala
+++ b/commons/src/main/scala/za/co/absa/spline/common/webmvc/jackson/NullAcceptingDeserializer.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2021 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.spline.common.webmvc.jackson
+
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer
+
+class NullAcceptingDeserializer extends StdDeserializer[Any](classOf[Any]) {
+
+  override def deserialize(jp: JsonParser, ctxt: DeserializationContext): Any = {
+    ctxt.readValue(jp, classOf[Any])
+  }
+
+}

--- a/commons/src/test/scala/za/co/absa/spline/common/webmvc/jackson/NullAcceptingDeserializerSpec.scala
+++ b/commons/src/test/scala/za/co/absa/spline/common/webmvc/jackson/NullAcceptingDeserializerSpec.scala
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2021 ABSA Group Limited
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.spline.common.webmvc.jackson
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+import com.fasterxml.jackson.databind.json.JsonMapper
+import com.fasterxml.jackson.databind.{ObjectMapper, PropertyNamingStrategies}
+import com.fasterxml.jackson.module.scala.DefaultScalaModule
+import com.twitter.finatra.jackson.FinatraInternalModules
+import com.twitter.finatra.jackson.caseclass.exceptions.CaseClassMappingException
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.mockito.MockitoSugar
+
+class NullAcceptingDeserializerSpec extends AnyFlatSpec with Matchers with MockitoSugar {
+
+  import za.co.absa.spline.common.webmvc.jackson.NullAcceptingDeserializerSpec._
+
+  behavior of "standard finatra deserializer"
+
+  it should "throw on null by default" in {
+    a[CaseClassMappingException] should be thrownBy {
+      objectMapper.readValue("""{ "str" : null }""", classOf[Foo])
+    }
+  }
+
+  behavior of "NullAcceptingDeserializer used via annotation"
+
+  it should "work normally when value is present" in {
+    val value = objectMapper.readValue("""{ "str" : "abc" }""", classOf[Bar])
+    value.str shouldBe "abc"
+  }
+
+  it should "accept null values" in {
+    val value = objectMapper.readValue("""{ "str" : null }""", classOf[Bar])
+    value.str shouldBe null
+  }
+
+  it should "be able to deserialize complex types" in {
+    val json = """{ "value" : { "a" : 42, "b" : "abc", "c" : [1,2,3] }}}"""
+    val value = objectMapper.readValue(json, classOf[Baz])
+    value.value shouldBe Map("a" -> 42, "b" -> "abc", "c" -> Seq(1,2,3))
+  }
+
+}
+
+object NullAcceptingDeserializerSpec {
+
+  private val objectMapper: ObjectMapper =
+    JsonMapper.builder.build()
+      .registerModule(DefaultScalaModule)
+      .setPropertyNamingStrategy(PropertyNamingStrategies.LOWER_CAMEL_CASE)
+      .registerModule(FinatraInternalModules.caseClassModule)
+
+  private case class Foo (
+    str: String
+  )
+
+  private case class Bar (
+    @JsonDeserialize(using = classOf[NullAcceptingDeserializer])
+    str: String
+  )
+
+  private case class Baz (
+    @JsonDeserialize(using = classOf[NullAcceptingDeserializer])
+    value: Any
+  )
+}

--- a/kafka-gateway/pom.xml
+++ b/kafka-gateway/pom.xml
@@ -67,12 +67,8 @@
             <artifactId>logback-classic</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.github.cerveada</groupId>
+            <groupId>com.twitter</groupId>
             <artifactId>finatra-jackson_${scala.compat.version}</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.github.cerveada</groupId>
-            <artifactId>finatra-json-annotations_${scala.compat.version}</artifactId>
         </dependency>
     </dependencies>
 

--- a/producer-model/pom.xml
+++ b/producer-model/pom.xml
@@ -35,8 +35,8 @@
         </dependency>
 
         <dependency>
-            <groupId>com.github.cerveada</groupId>
-            <artifactId>finatra-json-annotations_${scala.compat.version}</artifactId>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
         </dependency>
     </dependencies>
     

--- a/producer-model/src/main/scala/za/co/absa/spline/producer/model/v1_1/expressions.scala
+++ b/producer-model/src/main/scala/za/co/absa/spline/producer/model/v1_1/expressions.scala
@@ -16,8 +16,8 @@
 
 package za.co.absa.spline.producer.model.v1_1
 
-import com.twitter.finatra.json.annotations.NullValueAllowed
-
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+import za.co.absa.spline.common.webmvc.jackson.NullAcceptingDeserializer
 
 sealed trait ExpressionLike {
   def id: ExpressionLike.Id
@@ -67,7 +67,8 @@ case class Literal(
   override val id: ExpressionLike.Id,
   override val dataType: Option[Any] = None,
   override val extra: Map[String, Any] = Map.empty,
-  @NullValueAllowed() value: Any,
+  @JsonDeserialize(using = classOf[NullAcceptingDeserializer])
+  value: Any,
 ) extends ExpressionLike {
   override def childRefs: Seq[ExpressionLike.ChildRef] = Nil
 }

--- a/producer-rest-core/pom.xml
+++ b/producer-rest-core/pom.xml
@@ -87,12 +87,8 @@
             <version>2.9.2</version>
         </dependency>
         <dependency>
-            <groupId>com.github.cerveada</groupId>
+            <groupId>com.twitter</groupId>
             <artifactId>finatra-jackson_${scala.compat.version}</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.github.cerveada</groupId>
-            <artifactId>finatra-json-annotations_${scala.compat.version}</artifactId>
         </dependency>
 
         <!-- test scope -->


### PR DESCRIPTION
I was trying to get the class of the deserialized field in the deserializer, which seems to be not possible for annotation set deserializers, because they use different instantiation logic then the deserializers registered in mapper.

At the end it doesn't seem to be really needed since Any works fine for our cases.

We may need to revisit this if there is some specific type conversion for which it doesn't work, but that is not expected since we want to mostly avoid nulls anyway.
