### PR TITLE
spline #834 Ensure SSL validation is supported

### DIFF
--- a/admin/src/main/scala/za/co/absa/spline/admin/AdminCLI.scala
+++ b/admin/src/main/scala/za/co/absa/spline/admin/AdminCLI.scala
@@ -23,6 +23,7 @@ import scopt.{OptionDef, OptionParser}
 import za.co.absa.spline.admin.AdminCLI.AdminCLIConfig
 import za.co.absa.spline.common.ConsoleUtils._
 import za.co.absa.spline.common.SplineBuildInfo
+import za.co.absa.spline.common.scala13.Option
 import za.co.absa.spline.common.security.TLSUtils
 import za.co.absa.spline.persistence.AuxiliaryDBAction._
 import za.co.absa.spline.persistence.OnDBExistsAction.{Drop, Fail, Skip}
@@ -165,9 +166,7 @@ class AdminCLI(dbManagerFactory: ArangoManagerFactory) {
       .asInstanceOf[Logger]
       .setLevel(conf.logLevel)
 
-    val sslCtxOpt =
-      if (!conf.disableSslValidation) None
-      else Some(TLSUtils.TrustingAllSSLContext)
+    val sslCtxOpt = Option.when(conf.disableSslValidation)(TLSUtils.TrustingAllSSLContext)
 
     conf.cmd match {
       case DBInit(url, force, skip) =>

--- a/admin/src/main/scala/za/co/absa/spline/admin/AdminCLI.scala
+++ b/admin/src/main/scala/za/co/absa/spline/admin/AdminCLI.scala
@@ -91,9 +91,13 @@ class AdminCLI(dbManagerFactory: ArangoManagerFactory) {
           action ((str, conf) => conf.copy(logLevel = Level.valueOf(str))))
       }
 
-      // FIXME: rename 'insecure' to 'disable-ssl-validation'. See https://github.com/AbsaOSS/spline/issues/906
+      // FIXME: Deprecated since Spline 0.6.1. To be removed in Spline 1.0.0 - https://github.com/AbsaOSS/spline/issues/906
       (opt[Unit]('k', "insecure")
-        text s"Allow untrusted server connections when using SSL; disallowed by default."
+        text s"Deprecated. See --disable-ssl-validation"
+        action { case (_, conf) => conf.copy(disableSslValidation = true) })
+
+      (opt[Unit]("disable-ssl-validation")
+        text s"Disable validation of self-signed SSL certificates. (Don't use on production)."
         action { case (_, conf) => conf.copy(disableSslValidation = true) })
 
       this.placeNewLine()

--- a/admin/src/test/scala/za/co/absa/spline/admin/AdminCLISpec.scala
+++ b/admin/src/test/scala/za/co/absa/spline/admin/AdminCLISpec.scala
@@ -96,13 +96,13 @@ class AdminCLISpec
       } should include("--help")
     }
 
-    it should "when calling with option -k, create a non-validating SSLContext" in {
+    it should "when called with option -k, create a non-validating SSLContext" in {
       cli.exec(Array("db-exec", "arangodbs://foo/bar", "-k"))
       sslCtxCaptor.getValue.nonEmpty should be(true)
       sslCtxCaptor.getValue.get should be(TLSUtils.TrustingAllSSLContext)
     }
 
-    it should "when calling without option -k, do not create any custom SSLContext (leave default one)" in {
+    it should "when called without option -k, do not create any custom SSLContext (leave default one)" in {
       cli.exec(Array("db-exec", "arangodbs://foo/bar"))
       sslCtxCaptor.getValue.isEmpty should be(true)
     }

--- a/commons/src/main/scala/za/co/absa/spline/common/scala13/Option.scala
+++ b/commons/src/main/scala/za/co/absa/spline/common/scala13/Option.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2021 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.spline.common.scala13
+
+object Option {
+
+  import scala.language.implicitConversions
+
+  /** An Option factory which creates Some(x) if the argument is not null,
+   * and None if it is null.
+   *
+   * @param x the value
+   * @return Some(value) if value != null, None if value == null
+   */
+  def apply[A](x: A): Option[A] = if (x == null) None else Some(x)
+
+  /** An Option factory which returns `None` in a manner consistent with
+   * the collections hierarchy.
+   */
+  def empty[A]: Option[A] = None
+
+  /** When a given condition is true, evaluates the `a` argument and returns
+   * Some(a). When the condition is false, `a` is not evaluated and None is
+   * returned.
+   */
+  def when[A](cond: Boolean)(a: => A): Option[A] =
+    if (cond) Some(a) else None
+
+  /** Unless a given condition is true, this will evaluate the `a` argument and
+   * return Some(a). Otherwise, `a` is not evaluated and None is returned.
+   */
+  @inline def unless[A](cond: Boolean)(a: => A): Option[A] =
+    when(!cond)(a)
+}

--- a/commons/src/main/scala/za/co/absa/spline/common/security/TLSUtils.scala
+++ b/commons/src/main/scala/za/co/absa/spline/common/security/TLSUtils.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2021 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.spline.common.security
+
+import java.security.cert.X509Certificate
+import javax.net.ssl.{SSLContext, X509TrustManager}
+
+object TLSUtils {
+
+  lazy val TrustingAllSSLContext: SSLContext = {
+    val sslContext = SSLContext.getInstance("TLS")
+    sslContext.init(null, Array(TrustAll), null)
+    sslContext
+  }
+
+  // Bypasses both client and server validation.
+  private object TrustAll extends X509TrustManager {
+    override val getAcceptedIssuers: Array[X509Certificate] = Array.empty
+
+    override def checkClientTrusted(x509Certificates: Array[X509Certificate], s: String): Unit = {
+      // do nothing
+    }
+
+    override def checkServerTrusted(x509Certificates: Array[X509Certificate], s: String): Unit = {
+      // do nothing
+    }
+  }
+
+}

--- a/persistence/src/main/scala/za/co/absa/spline/persistence/ArangoManagerFactory.scala
+++ b/persistence/src/main/scala/za/co/absa/spline/persistence/ArangoManagerFactory.scala
@@ -20,17 +20,18 @@ import com.arangodb.async.ArangoDatabaseAsync
 import za.co.absa.spline.persistence.foxx.FoxxManagerImpl
 import za.co.absa.spline.persistence.migration.{MigrationScriptRepository, Migrator}
 
+import javax.net.ssl.SSLContext
 import scala.concurrent.ExecutionContext
 
 trait ArangoManagerFactory {
-  def create(connectionURL: ArangoConnectionURL): ArangoManager
+  def create(connectionURL: ArangoConnectionURL, maybeSSLContext: Option[SSLContext]): ArangoManager
 }
 
 class ArangoManagerFactoryImpl()(implicit ec: ExecutionContext) extends ArangoManagerFactory {
 
   import ArangoImplicits._
 
-  override def create(connectionURL: ArangoConnectionURL): ArangoManager = {
+  override def create(connectionURL: ArangoConnectionURL, maybeSSLContext: Option[SSLContext]): ArangoManager = {
     val scriptRepo = MigrationScriptRepository
 
     def dbManager(db: ArangoDatabaseAsync): ArangoManager = {
@@ -47,7 +48,7 @@ class ArangoManagerFactoryImpl()(implicit ec: ExecutionContext) extends ArangoMa
     }
 
     def dbFacade(): ArangoDatabaseFacade =
-      new ArangoDatabaseFacade(connectionURL)
+      new ArangoDatabaseFacade(connectionURL, maybeSSLContext)
 
     new AutoClosingArangoManagerProxy(dbManager, dbFacade)
   }

--- a/persistence/src/main/scala/za/co/absa/spline/persistence/ArangoRepoConfig.scala
+++ b/persistence/src/main/scala/za/co/absa/spline/persistence/ArangoRepoConfig.scala
@@ -22,6 +22,7 @@ import org.springframework.beans.factory.InitializingBean
 import org.springframework.context.annotation.{Bean, Configuration}
 import za.co.absa.commons.config.ConfTyped
 import za.co.absa.spline.common.config.DefaultConfigurationStack
+import za.co.absa.spline.common.scala13.Option
 import za.co.absa.spline.common.security.TLSUtils
 
 @Configuration
@@ -35,10 +36,7 @@ class ArangoRepoConfig extends InitializingBean with Logging {
   }
 
   @Bean def arangoDatabaseFacade: ArangoDatabaseFacade = {
-    val sslCtxOpt =
-      if (!Database.DisableSSLValidation) None
-      else Some(TLSUtils.TrustingAllSSLContext)
-
+    val sslCtxOpt = Option.when(Database.DisableSSLValidation)(TLSUtils.TrustingAllSSLContext)
     new ArangoDatabaseFacade(Database.ConnectionURL, sslCtxOpt)
   }
 

--- a/persistence/src/main/scala/za/co/absa/spline/persistence/ArangoRepoConfig.scala
+++ b/persistence/src/main/scala/za/co/absa/spline/persistence/ArangoRepoConfig.scala
@@ -22,6 +22,7 @@ import org.springframework.beans.factory.InitializingBean
 import org.springframework.context.annotation.{Bean, Configuration}
 import za.co.absa.commons.config.ConfTyped
 import za.co.absa.spline.common.config.DefaultConfigurationStack
+import za.co.absa.spline.common.security.TLSUtils
 
 @Configuration
 class ArangoRepoConfig extends InitializingBean with Logging {
@@ -33,7 +34,13 @@ class ArangoRepoConfig extends InitializingBean with Logging {
     log.info(s"Spline database URL: ${Database.ConnectionURL.asString}")
   }
 
-  @Bean def arangoDatabaseFacade: ArangoDatabaseFacade = new ArangoDatabaseFacade(Database.ConnectionURL)
+  @Bean def arangoDatabaseFacade: ArangoDatabaseFacade = {
+    val sslCtxOpt =
+      if (!Database.DisableSSLValidation) None
+      else Some(TLSUtils.TrustingAllSSLContext)
+
+    new ArangoDatabaseFacade(Database.ConnectionURL, sslCtxOpt)
+  }
 
   @Bean def arangoDatabase: ArangoDatabaseAsync = arangoDatabaseFacade.db
 
@@ -56,6 +63,9 @@ object ArangoRepoConfig extends DefaultConfigurationStack with ConfTyped {
 
     val LogFullQueryOnError: Boolean =
       conf.getBoolean(Prop("logFullQueryOnError"), false)
+
+    val DisableSSLValidation: Boolean =
+      conf.getBoolean(Prop("disableSslValidation"), true)
   }
 
 }


### PR DESCRIPTION
fixes #834 

- Conditionally create AllTrusting SSL context (only if disabling SSL validation is explicitly requested via a corresponding configuration property or CLI argument)
- Make `-k` argument completely optional
- Add `--disable-ssl-validation` and deprecate `-k`, `--insecure`