### PR TITLE
spline #928 Consumer: add filter by write mode

### DIFF
--- a/consumer-services/src/main/scala/za/co/absa/spline/consumer/service/repo/DataSourceRepository.scala
+++ b/consumer-services/src/main/scala/za/co/absa/spline/consumer/service/repo/DataSourceRepository.scala
@@ -27,9 +27,10 @@ trait DataSourceRepository {
     writeTimestampEnd: Long,
     pageRequest: PageRequest,
     sortRequest: SortRequest,
-    searchTerm: String,
-    writeApplicationId: String,
-    dataSourceUri: String)
+    maybeSearchTerm: Option[String],
+    maybeAppend: Option[Boolean],
+    maybeWriteApplicationId: Option[String],
+    maybeDataSourceUri: Option[String])
     (implicit ec: ExecutionContext): Future[(Seq[WriteEventInfo], Long)]
 
   def findByUsage(

--- a/consumer-services/src/main/scala/za/co/absa/spline/consumer/service/repo/ExecutionEventRepository.scala
+++ b/consumer-services/src/main/scala/za/co/absa/spline/consumer/service/repo/ExecutionEventRepository.scala
@@ -23,9 +23,10 @@ trait ExecutionEventRepository {
 
   def getTimestampRange(
     asAtTime: Long,
-    searchTerm: String,
-    applicationId: String,
-    dataSourceUri: String)
+    maybeSearchTerm: Option[String],
+    maybeAppend: Option[Boolean],
+    maybeApplicationId: Option[String],
+    maybeDataSourceUri: Option[String])
     (implicit ec: ExecutionContext): Future[(Long, Long)]
 
   def findByTimestampRange(
@@ -34,8 +35,9 @@ trait ExecutionEventRepository {
     timestampEnd: Long,
     pageRequest: PageRequest,
     sortRequest: SortRequest,
-    searchTerm: String,
-    applicationId: String,
-    dataSourceUri: String)
+    maybeSearchTerm: Option[String],
+    maybeAppend: Option[Boolean],
+    maybeApplicationId: Option[String],
+    maybeDataSourceUri: Option[String])
     (implicit ec: ExecutionContext): Future[(Seq[WriteEventInfo], Long)]
 }


### PR DESCRIPTION
fixes #928

- Added optional `append` query parameter to `/execution-events` and `/data-sources` routes.
Possible values are `true | false | 1 | 0 | undefined`
- Refactoring: 
  - replaced `NOT x` with `IS_NULL(x)` in AQL queries
  - replaced Scala type ascription with explicit boxing/unboxing where appropriate
  - converted nullable `T` to `Option[T]` where appropriate