### PR TITLE
Bugfix/spline 931 loosen output schema consistency check

### DIFF
--- a/producer-model-mapper/src/main/scala/za/co/absa/spline/producer/modelmapper/v1/OperationConverter.scala
+++ b/producer-model-mapper/src/main/scala/za/co/absa/spline/producer/modelmapper/v1/OperationConverter.scala
@@ -34,9 +34,7 @@ class OperationConverter(
       .mapValues(objectConverter.convert)
       .view.force // see: https://github.com/scala/bug/issues/4776
 
-    val output = maybeOutputConverter
-      .flatMap(_.convert(op1))
-      .getOrElse(Nil)
+    val maybeOutput = maybeOutputConverter.flatMap(_.convert(op1))
 
     val id = op1.id.toString
     val maybeName = operationNameExtractor(op1)
@@ -59,7 +57,7 @@ class OperationConverter(
           inputSources = rop1.inputSources,
           id = id,
           name = maybeName,
-          output = output,
+          output = maybeOutput,
           params = convertedParams,
           extra = extra
         )
@@ -68,7 +66,7 @@ class OperationConverter(
           id = id,
           name = maybeName,
           childIds = childIds,
-          output = output,
+          output = maybeOutput,
           params = convertedParams,
           extra = extra
         )

--- a/producer-model/src/main/scala/za/co/absa/spline/producer/model/v1_1/operations.scala
+++ b/producer-model/src/main/scala/za/co/absa/spline/producer/model/v1_1/operations.scala
@@ -23,7 +23,7 @@ sealed trait OperationLike {
   def id: Id
   def name: Option[Id]
   def childIds: Seq[Id]
-  def output: OperationLike.Schema
+  def output: Option[OperationLike.Schema]
   def params: Map[String, Any]
   def extra: Map[String, Any]
 }
@@ -47,7 +47,7 @@ case class DataOperation(
   override val id: Id,
   override val name: Option[OperationLike.Name] = None,
   override val childIds: Seq[Id] = Nil,
-  override val output: Seq[Attribute.Id] = Nil,
+  override val output: Option[OperationLike.Schema] = None,
   override val params: Map[String, Any] = Map.empty,
   override val extra: Map[String, Any] = Map.empty
 ) extends OperationLike
@@ -56,7 +56,7 @@ case class ReadOperation(
   inputSources: Seq[String],
   override val id: Id,
   override val name: Option[OperationLike.Name] = None,
-  override val output: Seq[Attribute.Id] = Nil,
+  override val output: Option[OperationLike.Schema] = None,
   override val params: Map[String, Any] = Map.empty,
   override val extra: Map[String, Any] = Map.empty
 ) extends OperationLike {
@@ -72,5 +72,5 @@ case class WriteOperation(
   override val params: Map[String, Any] = Map.empty,
   override val extra: Map[String, Any] = Map.empty
 ) extends OperationLike {
-  override def output: Seq[Attribute.Id] = Nil
+  override def output: Option[OperationLike.Schema] = None
 }

--- a/producer-model/src/main/scala/za/co/absa/spline/producer/model/v1_1/operations.scala
+++ b/producer-model/src/main/scala/za/co/absa/spline/producer/model/v1_1/operations.scala
@@ -17,12 +17,11 @@
 package za.co.absa.spline.producer.model.v1_1
 
 import za.co.absa.commons.graph.GraphImplicits.DAGNodeIdMapping
-import za.co.absa.spline.producer.model.v1_1.OperationLike.Id
 
 sealed trait OperationLike {
-  def id: Id
-  def name: Option[Id]
-  def childIds: Seq[Id]
+  def id: OperationLike.Id
+  def name: Option[OperationLike.Name]
+  def childIds: Seq[OperationLike.Id]
   def output: Option[OperationLike.Schema]
   def params: Map[String, Any]
   def extra: Map[String, Any]
@@ -44,9 +43,9 @@ object OperationLike {
 
 
 case class DataOperation(
-  override val id: Id,
+  override val id: OperationLike.Id,
   override val name: Option[OperationLike.Name] = None,
-  override val childIds: Seq[Id] = Nil,
+  override val childIds: Seq[OperationLike.Id] = Nil,
   override val output: Option[OperationLike.Schema] = None,
   override val params: Map[String, Any] = Map.empty,
   override val extra: Map[String, Any] = Map.empty
@@ -54,21 +53,21 @@ case class DataOperation(
 
 case class ReadOperation(
   inputSources: Seq[String],
-  override val id: Id,
+  override val id: OperationLike.Id,
   override val name: Option[OperationLike.Name] = None,
   override val output: Option[OperationLike.Schema] = None,
   override val params: Map[String, Any] = Map.empty,
   override val extra: Map[String, Any] = Map.empty
 ) extends OperationLike {
-  override def childIds: Seq[Id] = Nil
+  override def childIds: Seq[OperationLike.Id] = Nil
 }
 
 case class WriteOperation(
   outputSource: String,
   append: Boolean,
-  override val id: Id,
+  override val id: OperationLike.Id,
   override val name: Option[OperationLike.Name] = None,
-  override val childIds: Seq[Id],
+  override val childIds: Seq[OperationLike.Id],
   override val params: Map[String, Any] = Map.empty,
   override val extra: Map[String, Any] = Map.empty
 ) extends OperationLike {

--- a/producer-rest-core/src/main/scala/za/co/absa/spline/producer/rest/controller/ExecutionPlansController.scala
+++ b/producer-rest-core/src/main/scala/za/co/absa/spline/producer/rest/controller/ExecutionPlansController.scala
@@ -102,7 +102,7 @@ class ExecutionPlansController @Autowired()(
                 name: <string>,
                 // Array of preceding operations IDs (see above)
                 childIds: [<string>],
-                // [Optional] Output attribute IDs
+                // [Optional] Output attribute IDs. If output is undefined the server will try to infer it from the child operations' output.
                 output: [<string>],
                 // [Optional] Operation parameters
                 params: {...},

--- a/producer-rest-core/src/test/scala/za/co/absa/spline/producer/rest/controller/ExecutionPlansControllerDeserFixAspectSpec.scala
+++ b/producer-rest-core/src/test/scala/za/co/absa/spline/producer/rest/controller/ExecutionPlansControllerDeserFixAspectSpec.scala
@@ -72,6 +72,8 @@ class ExecutionPlansControllerDeserFixAspectSpec
 
 object ExecutionPlansControllerDeserFixAspectSpec {
 
+  import za.co.absa.commons.lang.OptionImplicits._
+
   class ProceedingJoinPointSpy(args: AnyRef*) extends ProceedingJoinPoint {
     var capturedProceedingArgs: Seq[AnyRef] = _
 
@@ -132,13 +134,13 @@ object ExecutionPlansControllerDeserFixAspectSpec {
           ReadOperation(
             id = "2",
             inputSources = Seq("foo", "bar"),
-            output = Seq("attr1"),
+            output = Seq("attr1").asOption,
             params = sampleMapWithRefs,
             extra = sampleMapWithRefs),
           ReadOperation(
             id = "3",
             inputSources = Seq("baz", "qux"),
-            output = Seq("attr2"),
+            output = Seq("attr2").asOption,
             params = sampleMapWithRefs,
             extra = sampleMapWithRefs)
         ),
@@ -146,13 +148,13 @@ object ExecutionPlansControllerDeserFixAspectSpec {
           DataOperation(
             id = "4",
             childIds = Seq("2"),
-            output = Seq("attr1", "attr3"),
+            output = Seq("attr1", "attr3").asOption,
             params = sampleMapWithRefs,
             extra = sampleMapWithRefs),
           DataOperation(
             id = "5",
             childIds = Seq("3"),
-            output = Seq("attr2", "attr4"),
+            output = Seq("attr2", "attr4").asOption,
             params = sampleMapWithRefs,
             extra = sampleMapWithRefs)
         )

--- a/producer-services/src/main/scala/za/co/absa/spline/producer/service/model/ExecutionPlanPersistentModelBuilder.scala
+++ b/producer-services/src/main/scala/za/co/absa/spline/producer/service/model/ExecutionPlanPersistentModelBuilder.scala
@@ -392,7 +392,7 @@ object ExecutionPlanPersistentModelBuilder {
 
             // output in undefined and all inputs are equals, so the output can be inferred
             case (Some(inSchemaInfo) +: maybeInSchemaInfos, None)
-              if maybeInSchemaInfos.forall(_.exists(inSchemaInfo.==)) =>
+              if maybeInSchemaInfos.forall(_.exists(_.oid == inSchemaInfo.oid)) =>
               schemaByOpId.updated(op.id, inSchemaInfo)
 
             // output is undefined and is not inferrable

--- a/rest-gateway/pom.xml
+++ b/rest-gateway/pom.xml
@@ -116,7 +116,7 @@
                     <dependency>
                         <groupId>za.co.absa.utils</groupId>
                         <artifactId>rest-api-doc-generator</artifactId>
-                        <version>1.0.2</version>
+                        <version>1.0.4</version>
                     </dependency>
                 </dependencies>
             </plugin>


### PR DESCRIPTION
The PR makes `Operation.output` optional. This makes it possible to distinguish between the _empty_ and _unspecified_ output.
The later is eligible for schema inference, while the former represents a _unit_ relation.

Also updated `rest-api-doc-generator` to the bugfixed version 1.0.4