### PR TITLE
spline #906 Admin: Remove deprecated '-k', '--insecure' keys

### DIFF
--- a/admin/src/main/scala/za/co/absa/spline/admin/AdminCLI.scala
+++ b/admin/src/main/scala/za/co/absa/spline/admin/AdminCLI.scala
@@ -91,11 +91,6 @@ class AdminCLI(dbManagerFactory: ArangoManagerFactory) {
           action ((str, conf) => conf.copy(logLevel = Level.valueOf(str))))
       }
 
-      // FIXME: Deprecated since Spline 0.6.1. To be removed in Spline 1.0.0 - https://github.com/AbsaOSS/spline/issues/906
-      (opt[Unit]('k', "insecure")
-        text s"Deprecated. See --disable-ssl-validation"
-        action { case (_, conf) => conf.copy(disableSslValidation = true) })
-
       (opt[Unit]("disable-ssl-validation")
         text s"Disable validation of self-signed SSL certificates. (Don't use on production)."
         action { case (_, conf) => conf.copy(disableSslValidation = true) })

--- a/admin/src/test/scala/za/co/absa/spline/admin/AdminCLISpec.scala
+++ b/admin/src/test/scala/za/co/absa/spline/admin/AdminCLISpec.scala
@@ -96,13 +96,13 @@ class AdminCLISpec
       } should include("--help")
     }
 
-    it should "when called with option -k, create a non-validating SSLContext" in {
-      cli.exec(Array("db-exec", "arangodbs://foo/bar", "-k"))
+    it should "when called with option --disable-ssl-validation, create a non-validating SSLContext" in {
+      cli.exec(Array("db-exec", "arangodbs://foo/bar", "--disable-ssl-validation"))
       sslCtxCaptor.getValue.nonEmpty should be(true)
       sslCtxCaptor.getValue.get should be(TLSUtils.TrustingAllSSLContext)
     }
 
-    it should "when called without option -k, do not create any custom SSLContext (leave default one)" in {
+    it should "not create any custom SSLContext (leave the default one) by default" in {
       cli.exec(Array("db-exec", "arangodbs://foo/bar"))
       sslCtxCaptor.getValue.isEmpty should be(true)
     }


### PR DESCRIPTION
fixes #906 
removes deprecated `-k` option from the Admin CLI