### PR TITLE
Enceladus #1894: S3 support for HdfsDataLineageWriter

### DIFF
--- a/commons/src/main/scala/za/co/absa/spline/common/S3Location.scala
+++ b/commons/src/main/scala/za/co/absa/spline/common/S3Location.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2018-2019 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.spline.common
+
+import scala.util.matching.Regex
+
+object S3Location {
+
+  /**
+   * Generally usable regex for validating S3 path, e.g. `s3://my-cool-bucket1/path/to/file/on/s3.txt`
+   * Protocols `s3`, `s3n`, and `s3a` are allowed.
+   * Bucket naming rules defined at [[https://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html#bucketnamingrules]] are instilled.
+   */
+  private val S3LocationRx: Regex = "(s3[an]?)://([-a-z0-9.]{3,63})/(.*)".r
+
+  implicit class StringS3LocationExt(val path: String) extends AnyVal {
+
+    def toS3Location: Option[SimpleS3Location] = PartialFunction.condOpt(path) {
+      case S3LocationRx(protocol, bucketName, relativePath) =>
+        SimpleS3Location(protocol, bucketName, relativePath)
+    }
+
+    def isValidS3Path: Boolean = S3LocationRx.pattern.matcher(path).matches
+  }
+}
+
+case class SimpleS3Location(protocol: String, bucketName: String, path: String) {
+  def s3String: String = s"$protocol://$bucketName/$path"
+}

--- a/commons/src/test/scala/za/co/absa/spline/common/S3LocationSpec.scala
+++ b/commons/src/test/scala/za/co/absa/spline/common/S3LocationSpec.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2018-2019 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.spline.common
+
+import org.scalatest.{FlatSpec, Matchers}
+import za.co.absa.spline.common.S3Location.StringS3LocationExt
+
+class S3LocationSpec extends FlatSpec with Matchers {
+
+  "StringS3LocationExt" should "parse S3 path from String using toS3Location" in {
+    "s3://mybucket-123/path/to/file.ext".toS3Location shouldBe Some(SimpleS3Location("s3", "mybucket-123", "path/to/file.ext"))
+    "s3n://mybucket-123/path/to/ends/with/slash/".toS3Location shouldBe Some(SimpleS3Location("s3n", "mybucket-123", "path/to/ends/with/slash/"))
+    "s3a://mybucket-123.asdf.cz/path-to-$_file!@#$.ext".toS3Location shouldBe Some(SimpleS3Location("s3a", "mybucket-123.asdf.cz", "path-to-$_file!@#$.ext"))
+  }
+
+  it should "find no valid S3 path when parsing invalid S3 path from String using toS3Location" in {
+    "s3x://mybucket-123/path/to/file/on/invalid/prefix".toS3Location shouldBe None
+    "s3://bb/some/path/but/bucketname/too/short".toS3Location shouldBe None
+  }
+
+  it should "check path using isValidS3Path" in {
+    "s3://mybucket-123/path/to/file.ext".isValidS3Path shouldBe true
+    "s3n://mybucket-123/path/to/ends/with/slash/".isValidS3Path shouldBe true
+    "s3a://mybucket-123.asdf.cz/path-to-$_file!@#$.ext".isValidS3Path shouldBe true
+
+    "s3x://mybucket-123/path/to/file/on/invalid/prefix".isValidS3Path shouldBe false
+    "s3://bb/some/path/but/bucketname/too/short".isValidS3Path shouldBe false
+  }
+
+}


### PR DESCRIPTION
Backported https://github.com/AbsaOSS/spline-spark-agent/pull/195 for version 0.3 requested in https://github.com/absaoss/enceladus/issues/1894

## Test-run
 - built this snapshot version of `spline`, built custom Enceladus 2.24.0-SNAPSHOT from master with this custom dependency and ran on EMR with dataset's conformed publish path being located on S3. The result now includes a `_LINEAGE` file:
 ```
$ aws --profile saml s3 ls s3://<my bucket name here>/publish/superhero/ --recursive
2021-09-08 12:44:03       4048 publish/superhero/enceladus_info_date=2020-08-06/enceladus_info_version=1/_INFO
2021-09-08 12:44:01      10600 publish/superhero/enceladus_info_date=2020-08-06/enceladus_info_version=1/_LINEAGE
2021-09-08 12:44:00          0 publish/superhero/enceladus_info_date=2020-08-06/enceladus_info_version=1/_SUCCESS
2021-09-08 12:44:00      46554 publish/superhero/enceladus_info_date=2020-08-06/enceladus_info_version=1/part-00000-e81b
a7e6-ee18-4fd7-8bfa-76759eb00907-c000.snappy.parquet
```