### PR TITLE
Bugfix/spline 961 consumer writeMode, datetime and durationNs

### DIFF
--- a/consumer-services/src/main/scala/za/co/absa/spline/consumer/service/model/WriteEventInfo.scala
+++ b/consumer-services/src/main/scala/za/co/absa/spline/consumer/service/model/WriteEventInfo.scala
@@ -16,6 +16,7 @@
 package za.co.absa.spline.consumer.service.model
 
 import io.swagger.annotations.ApiModelProperty
+import za.co.absa.spline.persistence.model.Progress
 
 case class WriteEventInfo
 (
@@ -40,14 +41,15 @@ case class WriteEventInfo
   @ApiModelProperty(value = "Output data source (or data) type")
   dataSourceType: String,
   @ApiModelProperty(value = "Write mode - (true=Append; false=Override)")
-  append: Boolean
+  append: WriteEventInfo.Append
 ) {
-  def this() = this(null, null, null, null, null, 0, 0, null, null, null, false)
+  def this() = this(null, null, null, null, null, null, null, null, null, null, null)
 }
 
 object WriteEventInfo {
   type Id = String
-  type Timestamp = Long
-  type DurationNs = Long
+  type Timestamp = java.lang.Long
+  type DurationNs = Option[Progress.JobDurationInNanos]
+  type Append = java.lang.Boolean
 }
 

--- a/consumer-services/src/main/scala/za/co/absa/spline/consumer/service/repo/DataSourceRepositoryImpl.scala
+++ b/consumer-services/src/main/scala/za/co/absa/spline/consumer/service/repo/DataSourceRepositoryImpl.scala
@@ -88,7 +88,8 @@ class DataSourceRepositoryImpl @Autowired()(db: ArangoDatabaseAsync) extends Dat
         |        "dataSourceName"   : ds.name,
         |        "dataSourceUri"    : ds.uri,
         |        "dataSourceType"   : lwe.execPlanDetails.dataSourceType,
-        |        "append"           : lwe.execPlanDetails.append
+        |        "append"           : lwe.execPlanDetails.append,
+        |        "durationNs"       : lwe.durationNs
         |    }
         |
         |    SORT resItem.@sortField @sortOrder

--- a/consumer-services/src/main/scala/za/co/absa/spline/consumer/service/repo/DataSourceRepositoryImpl.scala
+++ b/consumer-services/src/main/scala/za/co/absa/spline/consumer/service/repo/DataSourceRepositoryImpl.scala
@@ -84,11 +84,11 @@ class DataSourceRepositoryImpl @Autowired()(db: ArangoDatabaseAsync) extends Dat
         |        "frameworkName"    : lwe.execPlanDetails.frameworkName,
         |        "applicationName"  : lwe.execPlanDetails.applicationName,
         |        "applicationId"    : lwe.extra.appId,
-        |        "timestamp"        : lwe.timestamp || 0,
+        |        "timestamp"        : lwe.timestamp,
         |        "dataSourceName"   : ds.name,
         |        "dataSourceUri"    : ds.uri,
         |        "dataSourceType"   : lwe.execPlanDetails.dataSourceType,
-        |        "append"           : lwe.execPlanDetails.append || false
+        |        "append"           : lwe.execPlanDetails.append
         |    }
         |
         |    SORT resItem.@sortField @sortOrder

--- a/consumer-services/src/main/scala/za/co/absa/spline/consumer/service/repo/ExecutionEventRepositoryImpl.scala
+++ b/consumer-services/src/main/scala/za/co/absa/spline/consumer/service/repo/ExecutionEventRepositoryImpl.scala
@@ -114,7 +114,8 @@ class ExecutionEventRepositoryImpl @Autowired()(db: ArangoDatabaseAsync) extends
         |        "dataSourceName"   : ee.execPlanDetails.dataSourceName,
         |        "dataSourceUri"    : ee.execPlanDetails.dataSourceUri,
         |        "dataSourceType"   : ee.execPlanDetails.dataSourceType,
-        |        "append"           : ee.execPlanDetails.append
+        |        "append"           : ee.execPlanDetails.append,
+        |        "durationNs"       : ee.durationNs
         |    }
         |
         |    SORT resItem.@sortField @sortOrder


### PR DESCRIPTION
- Change type of `WriteEventInfo.append` & `WriteEventInfo.timestapm` properties to boxed to prevent misleading `0` and `false` values from appearing in the query result where no such data is available.
- Add missing `durationNs` property to the AQL queries, so that the value is passed to consumer API.