### PR TITLE
spline #969 Consumer API: Data Source list: apply INNER JOIN logic wh…

### DIFF
--- a/consumer-rest-core/src/main/scala/za/co/absa/spline/consumer/rest/controller/DataSourcesController.scala
+++ b/consumer-rest-core/src/main/scala/za/co/absa/spline/consumer/rest/controller/DataSourcesController.scala
@@ -43,10 +43,10 @@ class DataSourcesController @Autowired()(
   )
   def dataSources(
     @ApiParam(value = "Beginning of the last write time range (inclusive)", example = "0")
-    @RequestParam(value = "timestampStart", defaultValue = "0") writeTimestampStart: Long,
+    @RequestParam(value = "timestampStart", required = false) writeTimestampStart: java.lang.Long,
 
     @ApiParam(value = "End of the last write time range (inclusive)", example = "0")
-    @RequestParam(value = "timestampEnd", defaultValue = "9223372036854775807") writeTimestampEnd: Long,
+    @RequestParam(value = "timestampEnd", required = false) writeTimestampEnd: java.lang.Long,
 
     @ApiParam(value = "Timestamp of the request, if asAtTime equals 0, the current timestamp will be applied", example = "0")
     @RequestParam(value = "asAtTime", defaultValue = "0") asAtTime0: Long,
@@ -85,6 +85,8 @@ class DataSourcesController @Autowired()(
     val maybeAppend = append.asOption.map(Boolean.unbox)
     val maybeWriteApplicationId = writeApplicationId.nonBlankOption
     val maybeDataSourceUri = dataSourceUri.nonBlankOption
+    val maybeWriteTimestampStart = writeTimestampStart.asOption.map(Long.unbox)
+    val maybeWriteTimestampEnd = writeTimestampEnd.asOption.map(Long.unbox)
 
     val eventualDateRange =
       execEventsRepo.getTimestampRange(
@@ -97,8 +99,8 @@ class DataSourcesController @Autowired()(
     val eventualEventsWithCount =
       dataSourceRepo.find(
         asAtTime,
-        writeTimestampStart,
-        writeTimestampEnd,
+        maybeWriteTimestampStart,
+        maybeWriteTimestampEnd,
         pageRequest,
         sortRequest,
         maybeSearchTerm,

--- a/consumer-services/src/main/scala/za/co/absa/spline/consumer/service/repo/DataSourceRepository.scala
+++ b/consumer-services/src/main/scala/za/co/absa/spline/consumer/service/repo/DataSourceRepository.scala
@@ -23,8 +23,8 @@ trait DataSourceRepository {
 
   def find(
     asAtTime: Long,
-    writeTimestampStart: Option[Long],
-    writeTimestampEnd: Option[Long],
+    maybeWriteTimestampStart: Option[Long],
+    maybeWriteTimestampEnd: Option[Long],
     pageRequest: PageRequest,
     sortRequest: SortRequest,
     maybeSearchTerm: Option[String],

--- a/consumer-services/src/main/scala/za/co/absa/spline/consumer/service/repo/DataSourceRepository.scala
+++ b/consumer-services/src/main/scala/za/co/absa/spline/consumer/service/repo/DataSourceRepository.scala
@@ -23,8 +23,8 @@ trait DataSourceRepository {
 
   def find(
     asAtTime: Long,
-    writeTimestampStart: Long,
-    writeTimestampEnd: Long,
+    writeTimestampStart: Option[Long],
+    writeTimestampEnd: Option[Long],
     pageRequest: PageRequest,
     sortRequest: SortRequest,
     maybeSearchTerm: Option[String],

--- a/consumer-services/src/main/scala/za/co/absa/spline/consumer/service/repo/DataSourceRepositoryImpl.scala
+++ b/consumer-services/src/main/scala/za/co/absa/spline/consumer/service/repo/DataSourceRepositoryImpl.scala
@@ -34,8 +34,8 @@ class DataSourceRepositoryImpl @Autowired()(db: ArangoDatabaseAsync) extends Dat
 
   override def find(
     asAtTime: Long,
-    writeTimestampStart: Option[Long],
-    writeTimestampEnd: Option[Long],
+    maybeWriteTimestampStart: Option[Long],
+    maybeWriteTimestampEnd: Option[Long],
     pageRequest: PageRequest,
     sortRequest: SortRequest,
     maybeSearchTerm: Option[String],
@@ -105,8 +105,8 @@ class DataSourceRepositoryImpl @Autowired()(db: ArangoDatabaseAsync) extends Dat
         |""".stripMargin,
       Map(
         "asAtTime" -> Long.box(asAtTime),
-        "timestampStart" -> writeTimestampStart.map(Long.box).orNull,
-        "timestampEnd" -> writeTimestampEnd.map(Long.box).orNull,
+        "timestampStart" -> maybeWriteTimestampStart.map(Long.box).orNull,
+        "timestampEnd" -> maybeWriteTimestampEnd.map(Long.box).orNull,
         "pageOffset" -> Int.box(pageRequest.page - 1),
         "pageSize" -> Int.box(pageRequest.size),
         "sortField" -> sortRequest.sortField,

--- a/consumer-services/src/main/scala/za/co/absa/spline/consumer/service/repo/DataSourceRepositoryImpl.scala
+++ b/consumer-services/src/main/scala/za/co/absa/spline/consumer/service/repo/DataSourceRepositoryImpl.scala
@@ -46,7 +46,7 @@ class DataSourceRepositoryImpl @Autowired()(db: ArangoDatabaseAsync) extends Dat
 
     db.queryAs[WriteEventInfo](
       """
-        |WITH progress, progressOf, executionPlan, affects, dataSource
+        |WITH progress, dataSource
         |FOR ds IN dataSource
         |    FILTER ds._created <= @asAtTime
         |


### PR DESCRIPTION
- When at least one filter is enabled on the _Last execution_ in the _DataSource list_ query, the _INNER JOIN_ logic is applied.
- Improve _DataSource list_ query performance by replacing "DataSource -> ExecutionPlan -> Progress" traversing with the filter on the `Progress.execPlanDetails.dataSourceUri` indexed property.