### PR TITLE
Bugfix/spline 979 swagger

### DIFF
--- a/producer-model-mapper/src/main/scala/za/co/absa/spline/producer/modelmapper/v1/ModelMapperV1.scala
+++ b/producer-model-mapper/src/main/scala/za/co/absa/spline/producer/modelmapper/v1/ModelMapperV1.scala
@@ -80,11 +80,13 @@ object ModelMapperV1 extends ModelMapper {
     // But realistically speaking I don't believe there are many enough non-Spline v1 agents out there,
     // for the risk of misinterpreting the "durationNs" property in extras to be practically possible.
     // So I'm going to make a shortcut here for sake of performance and simplicity.
-    val durationNs = event.extra.get(FieldNamesV1.EventExtraInfo.DurationNs).
-      flatMap(PartialFunction.condOpt(_) {
-        case num: Long => num
-        case str: String if str.forall(_.isDigit) => str.toLong
-      })
+    val durationNs: Option[ExecutionEvent.DurationNs] = {
+      event.extra.get(FieldNamesV1.EventExtraInfo.DurationNs).
+        flatMap(PartialFunction.condOpt(_) {
+          case num: Long => num
+          case str: String if str.forall(_.isDigit) => str.toLong
+        })
+    }
 
     ExecutionEvent(
       planId = event.planId,

--- a/producer-model/src/main/scala/za/co/absa/spline/producer/model/v1_1/ExecutionEvent.scala
+++ b/producer-model/src/main/scala/za/co/absa/spline/producer/model/v1_1/ExecutionEvent.scala
@@ -16,12 +16,21 @@
 
 package za.co.absa.spline.producer.model.v1_1
 
+import za.co.absa.spline.producer.model.v1_1.ExecutionEvent._
+
 import java.util.UUID
+import scala.language.implicitConversions
 
 case class ExecutionEvent(
   planId: UUID,
   timestamp: Long,
-  durationNs: Option[Long],
+  durationNs: Option[DurationNs],
   error: Option[Any] = None,
   extra: Map[String, Any] = Map.empty
 )
+
+object ExecutionEvent {
+  type DurationNs = java.lang.Long
+
+  implicit def optJavaLong2OptScalaLong(opt: Option[java.lang.Long]): Option[Long] = opt.map(identity(_))
+}

--- a/producer-rest-core/src/main/scala/za/co/absa/spline/producer/rest/controller/ExecutionEventsController.scala
+++ b/producer-rest-core/src/main/scala/za/co/absa/spline/producer/rest/controller/ExecutionEventsController.scala
@@ -51,7 +51,7 @@ class ExecutionEventsController @Autowired()(
             // Time (milliseconds since Epoch) when the execution finished
             timestamp: <number>,
             // [Optional] Duration (in nanoseconds) of the execution
-            duration: <number>,
+            durationNs: <number>,
             // [Optional] Additional info about the error (in case there was an error during the execution)
             error: {...},
             // [Optional] Any other extra information related to the given execution event

--- a/producer-services/src/main/scala/za/co/absa/spline/producer/service/repo/ExecutionProducerRepositoryImpl.scala
+++ b/producer-services/src/main/scala/za/co/absa/spline/producer/service/repo/ExecutionProducerRepositoryImpl.scala
@@ -23,6 +23,7 @@ import org.springframework.stereotype.Repository
 import za.co.absa.spline.persistence.model._
 import za.co.absa.spline.persistence.tx.{ArangoTx, InsertQuery, TxBuilder}
 import za.co.absa.spline.persistence.{ArangoImplicits, Persister}
+import za.co.absa.spline.producer.model.v1_1.ExecutionEvent._
 import za.co.absa.spline.producer.model.{v1_1 => apiModel}
 import za.co.absa.spline.producer.service.InconsistentEntityException
 import za.co.absa.spline.producer.service.model.{ExecutionEventKeyCreator, ExecutionPlanPersistentModel, ExecutionPlanPersistentModelBuilder}


### PR DESCRIPTION
- Changes the generic type parameter for the `durationNs` property from Scala `Long` to Java `Long` along with the implicit conversion from `Option[Long]` to `Option[java.lang.Long]` respectively.
- fixed a typo in the Swagger doc