### PR TITLE
Feature/spline 978 UUID collision handling

### DIFF
--- a/build/parent-pom/pom.xml
+++ b/build/parent-pom/pom.xml
@@ -40,7 +40,7 @@
         <java.version>1.8</java.version>
         <scala.version>2.12.13</scala.version>
         <scala.compat.version>2.12</scala.compat.version>
-        <logback.version>1.2.3</logback.version>
+        <logback.version>1.2.6</logback.version>
         <slf4j.version>1.7.25</slf4j.version>
         <json4s.version>3.6.7</json4s.version>
         <spring.version>5.2.2.RELEASE</spring.version>

--- a/persistence/pom.xml
+++ b/persistence/pom.xml
@@ -62,7 +62,7 @@
         <dependency>
             <groupId>com.arangodb</groupId>
             <artifactId>arangodb-java-driver</artifactId>
-            <version>6.12.2</version>
+            <version>6.14.0</version>
         </dependency>
         <dependency>
             <groupId>com.arangodb</groupId>

--- a/persistence/src/main/scala/za/co/absa/spline/persistence/model/entities.scala
+++ b/persistence/src/main/scala/za/co/absa/spline/persistence/model/entities.scala
@@ -109,6 +109,7 @@ object DataSource {
   */
 case class ExecutionPlan(
   name: Option[ExecutionPlan.Name],
+  discriminator: Option[ExecutionPlan.Discriminator],
   systemInfo: Map[String, Any],
   agentInfo: Map[String, Any],
   extra: Map[String, Any],
@@ -117,6 +118,7 @@ case class ExecutionPlan(
 
 object ExecutionPlan {
   type Name = String
+  type Discriminator = String
 }
 
 /**
@@ -127,6 +129,7 @@ object ExecutionPlan {
 case class Progress(
   timestamp: Long,
   durationNs: Option[Progress.JobDurationInNanos],
+  discriminator: Option[ExecutionPlan.Discriminator],
   error: Option[Any],
   extra: Map[String, Any],
   override val _key: ArangoDocument.Key,

--- a/producer-model/src/main/scala/za/co/absa/spline/producer/model/v1_1/ExecutionEvent.scala
+++ b/producer-model/src/main/scala/za/co/absa/spline/producer/model/v1_1/ExecutionEvent.scala
@@ -18,13 +18,13 @@ package za.co.absa.spline.producer.model.v1_1
 
 import za.co.absa.spline.producer.model.v1_1.ExecutionEvent._
 
-import java.util.UUID
 import scala.language.implicitConversions
 
 case class ExecutionEvent(
-  planId: UUID,
+  planId: ExecutionPlan.Id,
   timestamp: Long,
   durationNs: Option[DurationNs],
+  discriminator: Option[ExecutionPlan.Discriminator] = None,
   error: Option[Any] = None,
   extra: Map[String, Any] = Map.empty
 )

--- a/producer-model/src/main/scala/za/co/absa/spline/producer/model/v1_1/executionPlan.scala
+++ b/producer-model/src/main/scala/za/co/absa/spline/producer/model/v1_1/executionPlan.scala
@@ -21,8 +21,9 @@ import za.co.absa.spline.common.validation.{Constraint, ValidationUtils}
 import java.util.UUID
 
 case class ExecutionPlan(
-  id: UUID = UUID.randomUUID(),
+  id: ExecutionPlan.Id = UUID.randomUUID(),
   name: Option[ExecutionPlan.Name],
+  discriminator: Option[ExecutionPlan.Discriminator] = None,
 
   operations: Operations,
   attributes: Seq[Attribute] = Nil,
@@ -45,8 +46,10 @@ case class ExecutionPlan(
 }
 
 object ExecutionPlan {
+  type Id = UUID
   type Name = String
   type DataSourceUri = String
+  type Discriminator = String
 }
 
 case class Operations(

--- a/producer-rest-core/src/main/scala/za/co/absa/spline/producer/rest/controller/ExecutionEventsController.scala
+++ b/producer-rest-core/src/main/scala/za/co/absa/spline/producer/rest/controller/ExecutionEventsController.scala
@@ -48,12 +48,20 @@ class ExecutionEventsController @Autowired()(
           {
             // Reference to the execution plan Id that was triggered
             planId: <UUID>,
+
+            // [Optional] A label that logically distinguish a group of one of multiple execution plans from another group.
+            // If set, it has to match the discriminator of the associated execution plan.
+            // The property is used for UUID collision detection.
+            discriminator: <string>,
+
             // Time (milliseconds since Epoch) when the execution finished
             timestamp: <number>,
+
             // [Optional] Duration (in nanoseconds) of the execution
             durationNs: <number>,
             // [Optional] Additional info about the error (in case there was an error during the execution)
             error: {...},
+
             // [Optional] Any other extra information related to the given execution event
             extra: {...}
           },

--- a/producer-rest-core/src/main/scala/za/co/absa/spline/producer/rest/controller/ExecutionPlansController.scala
+++ b/producer-rest-core/src/main/scala/za/co/absa/spline/producer/rest/controller/ExecutionPlansController.scala
@@ -52,6 +52,11 @@ class ExecutionPlansController @Autowired()(
           // [Optional] A name of the application (script, job etc) that this execution plan represents.
           name: <string>,
 
+          // [Optional] A label that logically distinguish a group of one of multiple execution plans from another group.
+          // If set, it has to match the discriminator of the associated execution events.
+          // The property is used for UUID collision detection.
+          discriminator: <string>,
+
           // Operation level lineage info
           operations: {
 

--- a/producer-services/src/main/scala/za/co/absa/spline/producer/service/UUIDCollisionDetectedException.scala
+++ b/producer-services/src/main/scala/za/co/absa/spline/producer/service/UUIDCollisionDetectedException.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2021 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.spline.producer.service
+
+import java.util.UUID
+
+class UUIDCollisionDetectedException(
+  entityName: String,
+  id: UUID,
+  discriminator: String
+) extends RuntimeException(s"$entityName UUID collision detected: $id, discriminator: $discriminator")

--- a/producer-services/src/main/scala/za/co/absa/spline/producer/service/model/ExecutionPlanPersistentModelBuilder.scala
+++ b/producer-services/src/main/scala/za/co/absa/spline/producer/service/model/ExecutionPlanPersistentModelBuilder.scala
@@ -78,6 +78,7 @@ class ExecutionPlanPersistentModelBuilder private(
   def build(): ExecutionPlanPersistentModel = {
     val pmExecutionPlan = pm.ExecutionPlan(
       name = ep.name,
+      discriminator = ep.discriminator,
       _key = ep.id.toString,
       systemInfo = ep.systemInfo.toJsonAs[Map[String, Any]],
       agentInfo = ep.agentInfo.map(_.toJsonAs[Map[String, Any]]).orNull,


### PR DESCRIPTION
- POM: upgraded _ArangoDB Java driver_ and _Logback_ dependencies
- Introduced `ExecutionPlan.discriminator` string property, which is additionally verified on every plan or event insert. If IDs of two entities match, but discriminators don't we conclude detected collision. 