### PR TITLE
spline #1043 REST: Max timeout config option

### DIFF
--- a/build/parent-pom/pom.xml
+++ b/build/parent-pom/pom.xml
@@ -275,7 +275,7 @@
             <dependency>
                 <groupId>za.co.absa.commons</groupId>
                 <artifactId>commons_${scala.compat.version}</artifactId>
-                <version>0.0.26</version>
+                <version>1.0.2</version>
             </dependency>
 
             <!-- Apache Commons -->

--- a/commons/src/main/scala/za/co/absa/spline/common/config/HttpConfiguration.scala
+++ b/commons/src/main/scala/za/co/absa/spline/common/config/HttpConfiguration.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2022 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.spline.common.config
+
+import org.apache.commons.configuration.Configuration
+import za.co.absa.commons.config.ConfTyped
+import za.co.absa.commons.config.ConfigurationImplicits._
+
+import scala.concurrent.duration._
+
+trait HttpConfiguration {
+  this: ConfTyped with Configuration =>
+
+  val MaybeDefaultTimeout: Option[Duration] = this.getOptionalLong(Prop("timeoutDefault")).map(_.millis)
+  val MaybeMaximumTimeout: Option[Duration] = this.getOptionalLong(Prop("timeoutMaximum")).map(_.millis)
+
+}

--- a/commons/src/main/scala/za/co/absa/spline/common/config/HttpConfiguration.scala
+++ b/commons/src/main/scala/za/co/absa/spline/common/config/HttpConfiguration.scala
@@ -19,13 +19,26 @@ package za.co.absa.spline.common.config
 import org.apache.commons.configuration.Configuration
 import za.co.absa.commons.config.ConfTyped
 import za.co.absa.commons.config.ConfigurationImplicits._
+import za.co.absa.spline.common.config.HttpConfiguration.{DefaultDefaultTimeout, DefaultMaximumTimeout}
 
 import scala.concurrent.duration._
 
 trait HttpConfiguration {
   this: ConfTyped with Configuration =>
 
-  val MaybeDefaultTimeout: Option[Duration] = this.getOptionalLong(Prop("timeoutDefault")).map(_.millis)
-  val MaybeMaximumTimeout: Option[Duration] = this.getOptionalLong(Prop("timeoutMaximum")).map(_.millis)
+  val DefaultTimeout: Duration =
+    this.getOptionalLong(Prop("timeoutDefault"))
+      .map(_.millis)
+      .getOrElse(DefaultDefaultTimeout)
 
+  val MaximumTimeout: Duration =
+    this.getOptionalLong(Prop("timeoutMaximum"))
+      .map(_.millis)
+      .getOrElse(DefaultMaximumTimeout)
+
+}
+
+object HttpConfiguration {
+  val DefaultDefaultTimeout: Duration = 2.minutes
+  val DefaultMaximumTimeout: Duration = 1.hour
 }

--- a/commons/src/main/scala/za/co/absa/spline/common/webmvc/ScalaFutureMethodReturnValueHandler.scala
+++ b/commons/src/main/scala/za/co/absa/spline/common/webmvc/ScalaFutureMethodReturnValueHandler.scala
@@ -16,6 +16,7 @@
 
 package za.co.absa.spline.common.webmvc
 
+import org.slf4s.Logging
 import org.springframework.core.MethodParameter
 import org.springframework.lang.Nullable
 import org.springframework.web.context.request.async.{DeferredResult, WebAsyncUtils}
@@ -23,15 +24,23 @@ import org.springframework.web.context.request.{NativeWebRequest, WebRequest}
 import org.springframework.web.method.support.{AsyncHandlerMethodReturnValueHandler, ModelAndViewContainer}
 import org.springframework.web.servlet.mvc.method.annotation.DeferredResultMethodReturnValueHandler
 
+import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}
 
 
-class ScalaFutureMethodReturnValueHandler()(implicit ec: ExecutionContext)
+class ScalaFutureMethodReturnValueHandler(
+  maybeDefaultTimeout: Option[Duration],
+  maybeMaximumTimeout: Option[Duration]
+)(implicit ec: ExecutionContext)
   extends DeferredResultMethodReturnValueHandler
-    with AsyncHandlerMethodReturnValueHandler {
+    with AsyncHandlerMethodReturnValueHandler
+    with Logging {
 
   import ScalaFutureMethodReturnValueHandler._
+
+  log.debug(s"Default timeout: $maybeDefaultTimeout")
+  log.debug(s"Maximum timeout: $maybeMaximumTimeout")
 
   protected type F <: Future[_]
 
@@ -44,6 +53,7 @@ class ScalaFutureMethodReturnValueHandler()(implicit ec: ExecutionContext)
   override def handleReturnValue(retVal: Any, retType: MethodParameter, mav: ModelAndViewContainer, req: NativeWebRequest): Unit = retVal match {
     case future: F =>
       val maybeTimeout = getFutureTimeout(future, req)
+      log.debug(s"Future timeout: $maybeTimeout")
       val deferredResult = toDeferredResult(future, maybeTimeout)
       WebAsyncUtils
         .getAsyncManager(req)
@@ -53,7 +63,11 @@ class ScalaFutureMethodReturnValueHandler()(implicit ec: ExecutionContext)
   }
 
   protected def getFutureTimeout(future: F, req: WebRequest): Option[Long] =
-    Option(req.getHeader(TIMEOUT_HEADER)).map(_.toLong)
+    getTimeout(
+      Option(req.getHeader(TIMEOUT_HEADER)).map(_.toLong.millis),
+      maybeDefaultTimeout,
+      maybeMaximumTimeout
+    ).map(_.toMillis)
 
   private def toDeferredResult(returnValue: Future[_], timeout: Option[Long]): DeferredResult[_] =
     new DeferredResult[Any](timeout.map(Long.box).orNull) {
@@ -66,4 +80,33 @@ class ScalaFutureMethodReturnValueHandler()(implicit ec: ExecutionContext)
 
 object ScalaFutureMethodReturnValueHandler {
   private val TIMEOUT_HEADER = "X-SPLINE-TIMEOUT"
+
+  private def convertNegOrZeroToInf(t: Duration): Duration = {
+    if (t.isFinite() && t.toMillis < 1) Duration.Inf
+    else t
+  }
+
+  private def convertInfToZero(t: Duration): Duration = {
+    if (t.isFinite()) t
+    else 0.millis
+  }
+
+  private[webmvc] def getTimeout(
+    maybeRequestedTimeout: Option[Duration],
+    maybeDefaultTimeout: Option[Duration],
+    maybeMaximumTimeout: Option[Duration]
+  ): Option[Duration] = {
+
+    val requestedTOpt = maybeRequestedTimeout.map(convertNegOrZeroToInf)
+    val defaultTOpt = maybeDefaultTimeout.map(convertNegOrZeroToInf)
+    val maximumTOpt = maybeMaximumTimeout.map(convertNegOrZeroToInf)
+
+    val desiredTOpt = requestedTOpt.orElse(defaultTOpt)
+
+    desiredTOpt
+      .flatMap(t => maximumTOpt.map(t.min)) // apply threshold
+      .orElse(maximumTOpt) // take threshold if value is empty
+      .orElse(desiredTOpt) // otherwise accept desired value
+      .map(convertInfToZero)
+  }
 }

--- a/commons/src/test/scala/za/co/absa/spline/common/webmvc/ScalaFutureMethodReturnValueHandlerSpec.scala
+++ b/commons/src/test/scala/za/co/absa/spline/common/webmvc/ScalaFutureMethodReturnValueHandlerSpec.scala
@@ -16,8 +16,6 @@
 
 package za.co.absa.spline.common.webmvc
 
-import java.util.concurrent.CompletionStage
-
 import org.mockito.Mockito._
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -27,17 +25,21 @@ import org.springframework.util.concurrent.ListenableFuture
 import org.springframework.web.context.request.async.DeferredResult
 import za.co.absa.spline.common.webmvc.ScalaFutureMethodReturnValueHandlerSpec.{SubFuture, mockWith}
 
+import java.util.concurrent.CompletionStage
+import scala.concurrent.duration.Duration.Inf
 import scala.concurrent.{ExecutionContext, Future}
 import scala.reflect.ClassTag
 
 class ScalaFutureMethodReturnValueHandlerSpec extends AnyFlatSpec with MockitoSugar with Matchers {
 
+  import scala.concurrent.duration._
+
   private implicit val ec: ExecutionContext = mock[ExecutionContext]
-  private val handler = new ScalaFutureMethodReturnValueHandler
+  private val handler = new ScalaFutureMethodReturnValueHandler(None, None)
 
-  behavior of "ScalaFutureMethodReturnValueHandler"
+  behavior of "supportsReturnType()"
 
-  it should "supportsReturnType" in {
+  it should "report supported return types correctly" in {
     handler.supportsReturnType(mockWith[MethodParameter, Class[_]](_.getParameterType, classOf[Future[_]])) should be(true)
     handler.supportsReturnType(mockWith[MethodParameter, Class[_]](_.getParameterType, classOf[SubFuture])) should be(true)
     handler.supportsReturnType(mockWith[MethodParameter, Class[_]](_.getParameterType, classOf[DeferredResult[_]])) should be(true)
@@ -46,13 +48,50 @@ class ScalaFutureMethodReturnValueHandlerSpec extends AnyFlatSpec with MockitoSu
     handler.supportsReturnType(mockWith[MethodParameter, Class[_]](_.getParameterType, classOf[AnyRef])) should be(false)
   }
 
-  "isAsyncReturnValue" should "return true for any Future type" in {
+  behavior of "isAsyncReturnValue()"
+
+  it should "return true for any Future type" in {
     handler.isAsyncReturnValue(mock[Future[_]], null) should be(true)
     handler.isAsyncReturnValue(mock[SubFuture], null) should be(true)
     handler.isAsyncReturnValue(mock[AnyRef], null) should be(false)
     handler.isAsyncReturnValue(null, null) should be(false)
   }
 
+  Seq(Inf, 0.millis, -1.millis).foreach(inf => {
+    behavior of s"getTimeout() [infinite = $inf]"
+
+    it should "return None when all arguments are None" in {
+      ScalaFutureMethodReturnValueHandler.getTimeout(None, None, None) should be(None)
+    }
+
+    it should "return default timeout when requested timeout is unspecified" in {
+      ScalaFutureMethodReturnValueHandler.getTimeout(None, Some(42.millis), None) should equal(Some(42.millis))
+      ScalaFutureMethodReturnValueHandler.getTimeout(None, Some(42.millis), Some(777.millis)) should equal(Some(42.millis))
+    }
+
+    it should s"return requested timeout regardless of default timeout settings" in {
+      ScalaFutureMethodReturnValueHandler.getTimeout(Some(42.millis), None, None) should equal(Some(42.millis))
+      ScalaFutureMethodReturnValueHandler.getTimeout(Some(42.millis), Some(1.milli), None) should equal(Some(42.millis))
+      ScalaFutureMethodReturnValueHandler.getTimeout(Some(42.millis), Some(100.milli), None) should equal(Some(42.millis))
+      ScalaFutureMethodReturnValueHandler.getTimeout(Some(42.millis), Some(inf), None) should equal(Some(42.millis))
+    }
+
+    it should s"return threshold timeout when no timeout is specified" in {
+      ScalaFutureMethodReturnValueHandler.getTimeout(None, None, Some(10.millis)) should equal(Some(10.millis))
+    }
+
+    it should s"return threshold timeout when any of timeouts exceeds threshold value" in {
+      ScalaFutureMethodReturnValueHandler.getTimeout(Some(42.millis), None, Some(10.millis)) should equal(Some(10.millis))
+      ScalaFutureMethodReturnValueHandler.getTimeout(None, Some(42.millis), Some(10.millis)) should equal(Some(10.millis))
+      ScalaFutureMethodReturnValueHandler.getTimeout(None, Some(inf), Some(10.millis)) should equal(Some(10.millis))
+      ScalaFutureMethodReturnValueHandler.getTimeout(Some(inf), None, Some(10.millis)) should equal(Some(10.millis))
+    }
+
+    it should s"return 0 when default or requested timeout is infinite" in {
+      ScalaFutureMethodReturnValueHandler.getTimeout(Some(inf), None, None) should equal(Some(0.millis))
+      ScalaFutureMethodReturnValueHandler.getTimeout(None, Some(inf), None) should equal(Some(0.millis))
+    }
+  })
 }
 
 object ScalaFutureMethodReturnValueHandlerSpec extends MockitoSugar {

--- a/consumer-rest-core/src/main/scala/za/co/absa/spline/consumer/rest/ConsumerRESTConfig.scala
+++ b/consumer-rest-core/src/main/scala/za/co/absa/spline/consumer/rest/ConsumerRESTConfig.scala
@@ -23,7 +23,7 @@ import org.springframework.web.method.support.HandlerMethodReturnValueHandler
 import org.springframework.web.servlet.config.annotation.{EnableWebMvc, WebMvcConfigurer}
 import za.co.absa.commons.config.ConfTyped
 import za.co.absa.spline.common
-import za.co.absa.spline.common.config.DefaultConfigurationStack
+import za.co.absa.spline.common.config.{DefaultConfigurationStack, HttpConfiguration}
 import za.co.absa.spline.common.webmvc.jackson.ObjectMapperBeanPostProcessor
 import za.co.absa.spline.common.webmvc.{ScalaFutureMethodReturnValueHandler, UnitMethodReturnValueHandler}
 
@@ -41,7 +41,10 @@ class ConsumerRESTConfig extends WebMvcConfigurer {
 
   override def addReturnValueHandlers(returnValueHandlers: util.List[HandlerMethodReturnValueHandler]): Unit = {
     returnValueHandlers.add(new UnitMethodReturnValueHandler)
-    returnValueHandlers.add(new ScalaFutureMethodReturnValueHandler)
+    returnValueHandlers.add(new ScalaFutureMethodReturnValueHandler(
+      maybeDefaultTimeout = ConsumerRESTConfig.MaybeDefaultTimeout,
+      maybeMaximumTimeout = ConsumerRESTConfig.MaybeMaximumTimeout
+    ))
   }
 
   @Bean def jacksonConfigurer = new ObjectMapperBeanPostProcessor(_
@@ -54,8 +57,11 @@ class ConsumerRESTConfig extends WebMvcConfigurer {
   }
 }
 
-object ConsumerRESTConfig extends DefaultConfigurationStack with ConfTyped {
+object ConsumerRESTConfig
+  extends DefaultConfigurationStack
+    with ConfTyped
+    with HttpConfiguration {
 
-  override val rootPrefix: String = "spline"
+  override def rootPrefix: String = "spline.consumer"
 
 }

--- a/consumer-rest-core/src/main/scala/za/co/absa/spline/consumer/rest/ConsumerRESTConfig.scala
+++ b/consumer-rest-core/src/main/scala/za/co/absa/spline/consumer/rest/ConsumerRESTConfig.scala
@@ -42,8 +42,8 @@ class ConsumerRESTConfig extends WebMvcConfigurer {
   override def addReturnValueHandlers(returnValueHandlers: util.List[HandlerMethodReturnValueHandler]): Unit = {
     returnValueHandlers.add(new UnitMethodReturnValueHandler)
     returnValueHandlers.add(new ScalaFutureMethodReturnValueHandler(
-      maybeDefaultTimeout = ConsumerRESTConfig.MaybeDefaultTimeout,
-      maybeMaximumTimeout = ConsumerRESTConfig.MaybeMaximumTimeout
+      defaultTimeout = ConsumerRESTConfig.DefaultTimeout,
+      maximumTimeout = ConsumerRESTConfig.MaximumTimeout
     ))
   }
 

--- a/producer-rest-core/src/main/scala/za/co/absa/spline/producer/rest/ProducerRESTConfig.scala
+++ b/producer-rest-core/src/main/scala/za/co/absa/spline/producer/rest/ProducerRESTConfig.scala
@@ -43,8 +43,8 @@ class ProducerRESTConfig extends WebMvcConfigurer {
   override def addReturnValueHandlers(returnValueHandlers: util.List[HandlerMethodReturnValueHandler]): Unit = {
     returnValueHandlers.add(new UnitMethodReturnValueHandler)
     returnValueHandlers.add(new ScalaFutureMethodReturnValueHandler(
-      maybeDefaultTimeout = ProducerRESTConfig.MaybeDefaultTimeout,
-      maybeMaximumTimeout = ProducerRESTConfig.MaybeMaximumTimeout
+      defaultTimeout = ProducerRESTConfig.DefaultTimeout,
+      maximumTimeout = ProducerRESTConfig.MaximumTimeout
     ))
   }
 

--- a/producer-rest-core/src/main/scala/za/co/absa/spline/producer/rest/ProducerRESTConfig.scala
+++ b/producer-rest-core/src/main/scala/za/co/absa/spline/producer/rest/ProducerRESTConfig.scala
@@ -22,7 +22,9 @@ import com.twitter.finatra.jackson.FinatraInternalModules
 import org.springframework.context.annotation.{Bean, ComponentScan, Configuration}
 import org.springframework.web.method.support.HandlerMethodReturnValueHandler
 import org.springframework.web.servlet.config.annotation.{EnableWebMvc, WebMvcConfigurer}
+import za.co.absa.commons.config.ConfTyped
 import za.co.absa.spline.common
+import za.co.absa.spline.common.config.{DefaultConfigurationStack, HttpConfiguration}
 import za.co.absa.spline.common.webmvc.jackson.ObjectMapperBeanPostProcessor
 import za.co.absa.spline.common.webmvc.{ScalaFutureMethodReturnValueHandler, UnitMethodReturnValueHandler}
 
@@ -40,11 +42,23 @@ class ProducerRESTConfig extends WebMvcConfigurer {
 
   override def addReturnValueHandlers(returnValueHandlers: util.List[HandlerMethodReturnValueHandler]): Unit = {
     returnValueHandlers.add(new UnitMethodReturnValueHandler)
-    returnValueHandlers.add(new ScalaFutureMethodReturnValueHandler)
+    returnValueHandlers.add(new ScalaFutureMethodReturnValueHandler(
+      maybeDefaultTimeout = ProducerRESTConfig.MaybeDefaultTimeout,
+      maybeMaximumTimeout = ProducerRESTConfig.MaybeMaximumTimeout
+    ))
   }
 
   @Bean def jacksonConfigurer = new ObjectMapperBeanPostProcessor(_
     .registerModule(DefaultScalaModule)
     .setPropertyNamingStrategy(PropertyNamingStrategies.LOWER_CAMEL_CASE)
     .registerModule(FinatraInternalModules.caseClassModule))
+}
+
+object ProducerRESTConfig
+  extends DefaultConfigurationStack
+    with ConfTyped
+    with HttpConfiguration {
+
+  override def rootPrefix: String = "spline.producer"
+
 }

--- a/rest-gateway/pom.xml
+++ b/rest-gateway/pom.xml
@@ -121,7 +121,7 @@
                     <dependency>
                         <groupId>za.co.absa.utils</groupId>
                         <artifactId>rest-api-doc-generator</artifactId>
-                        <version>1.0.4</version>
+                        <version>1.0.5</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/rest-gateway/src/main/webapp/META-INF/context.xml
+++ b/rest-gateway/src/main/webapp/META-INF/context.xml
@@ -22,4 +22,10 @@
     -->
     <Environment name="spline/database/connectionUrl" type="java.lang.String" override="false"/>
 
+    <Environment name="spline/producer/timeoutDefault" type="java.lang.String" override="false"/>
+    <Environment name="spline/producer/timeoutMaximum" type="java.lang.String" override="false"/>
+
+    <Environment name="spline/consumer/timeoutDefault" type="java.lang.String" override="false"/>
+    <Environment name="spline/consumer/timeoutMaximum" type="java.lang.String" override="false"/>
+
 </Context>


### PR DESCRIPTION
Add the following options to the Producer and Consumer REST Gateway:
- `spline.[consumer|producer].timeoutDefault` - default async request timeout if one isn't specified by the client
- `spline.[consumer|producer].timeoutMaximum` - async timeout threshold that is applied to both default and user requested timeout value.

Both properties are optional. By default, timeout is 2 minutes, and the maximum one is 1 hour