### PR TITLE
spline #1049 Admin CLI :: 401 not authorized when user password is empty

### DIFF
--- a/persistence/src/main/scala/com/arangodb/internal/InternalArangoDatabaseOps.scala
+++ b/persistence/src/main/scala/com/arangodb/internal/InternalArangoDatabaseOps.scala
@@ -34,10 +34,11 @@ class InternalArangoDatabaseOps(db: ArangoDatabaseAsync)(implicit ec: ExecutionC
   def restClient: RESTClient = {
     val asyncExecutable = db.asInstanceOf[ArangoExecuteable[ArangoExecutorAsync]]
     val ArangoExecutorAsyncDestructor(vstComm) = asyncExecutable.executor
-    val VstCommunicationDestructor(ConnectionParams(hostDescription, user, password, maybeSslContext)) = vstComm
+    val VstCommunicationDestructor(ConnectionParams(hostDescription, user, maybePassword, maybeSslContext)) = vstComm
     val scheme = if (maybeSslContext.isDefined) "https" else "http"
     val host = hostDescription.getHost
     val port = hostDescription.getPort
+    val password = maybePassword.getOrElse("")
     val maybeCredentials = Option(user).map(user => new UsernamePasswordCredentials(user, password))
 
     new RESTClientApacheHttpImpl(new URI(s"$scheme://$host:$port/_db/${db.name}"), maybeCredentials, maybeSslContext)

--- a/persistence/src/main/scala/com/arangodb/internal/velocystream/VstCommunicationDestructor.scala
+++ b/persistence/src/main/scala/com/arangodb/internal/velocystream/VstCommunicationDestructor.scala
@@ -32,7 +32,7 @@ object VstCommunicationDestructor {
   case class ConnectionParams(
     hostDescription: HostDescription,
     user: String,
-    password: String,
+    password: Option[String],
     sslContext: Option[SSLContext]
   )
 
@@ -44,7 +44,7 @@ object VstCommunicationDestructor {
     val connParams = ConnectionParams(
       host.getDescription,
       comm.user,
-      comm.password,
+      Option(comm.password),
       Option(sslContext)
     )
 


### PR DESCRIPTION
Fixes ArangoDB REST basic auth in case the user password is empty by replacing `null` with empty string.