### PR TITLE
Feature/spline 1048 admin collection props

### DIFF
--- a/admin/src/main/scala/za/co/absa/spline/admin/AdminCLI.scala
+++ b/admin/src/main/scala/za/co/absa/spline/admin/AdminCLI.scala
@@ -49,9 +49,9 @@ object AdminCLI extends App {
 
     def dbCommandOptions: Seq[OptionDef[_, AdminCLIConfig]] = Seq(
       p.arg[String]("<db_url>")
-        required()
-        text s"ArangoDB connection string in the format: ${ArangoConnectionURL.HumanReadableFormat}"
-        action { case (url, c@AdminCLIConfig(cmd: DBCommand, _, _)) => c.copy(cmd.dbUrl = ArangoConnectionURL(url)) }
+        .required()
+        .text(s"ArangoDB connection string in the format: ${ArangoConnectionURL.HumanReadableFormat}")
+        .action { case (url, c@AdminCLIConfig(cmd: DBCommand, _, _)) => c.copy(cmd.dbUrl = ArangoConnectionURL(url)) }
     )
   }
 
@@ -89,128 +89,129 @@ class AdminCLI(dbManagerFactory: ArangoManagerFactory) {
         val logLevels = classOf[Level].getFields.collect { case f if f.getType == f.getDeclaringClass => f.getName }
         val logLevelsString = logLevels.mkString(", ")
 
-        (opt[String]('l', "log-level")
-          text s"Log level ($logLevelsString). Default is ${AdminCLIConfig().logLevel}."
-          validate (l => if (logLevels.contains(l.toUpperCase)) success else failure(s"<log-level> should be one of: $logLevelsString"))
-          action ((str, conf) => conf.copy(logLevel = Level.valueOf(str))))
+        opt[String]('l', "log-level")
+          .text(s"Log level ($logLevelsString). Default is ${AdminCLIConfig().logLevel}.")
+          .validate(l => if (logLevels.contains(l.toUpperCase)) success else failure(s"<log-level> should be one of: $logLevelsString"))
+          .action((str, conf) => conf.copy(logLevel = Level.valueOf(str)))
       }
 
-      (opt[Unit]("disable-ssl-validation")
-        text s"Disable validation of self-signed SSL certificates. (Don't use on production)."
-        action { case (_, conf) => conf.copy(disableSslValidation = true) })
+      opt[Unit]("disable-ssl-validation")
+        .text(s"Disable validation of self-signed SSL certificates. (Don't use on production).")
+        .action((_, conf) => conf.copy(disableSslValidation = true))
 
       this.placeNewLine()
 
-      (cmd("db-init")
-        action ((_, c) => c.copy(cmd = DBInit()))
-        text "Initialize Spline database"
-        children(
-        opt[Unit]('f', "force")
-          text "Re-create the database if one already exists."
-          action { case (_, c@AdminCLIConfig(cmd: DBInit, _, _)) => c.copy(cmd.copy(force = true)) },
-        opt[Unit]('s', "skip")
-          text "Skip existing database. Don't throw error, just end."
-          action { case (_, c@AdminCLIConfig(cmd: DBInit, _, _)) => c.copy(cmd.copy(skip = true)) },
+      cmd("db-init")
+        .action((_, c) => c.copy(cmd = DBInit()))
+        .text("Initialize Spline database")
+        .children(
+          opt[Unit]('f', "force")
+            .text("Re-create the database if one already exists.")
+            .action { case (_, c@AdminCLIConfig(cmd: DBInit, _, _)) => c.copy(cmd.copy(force = true)) },
+          opt[Unit]('s', "skip")
+            .text("Skip existing database. Don't throw error, just end.")
+            .action { case (_, c@AdminCLIConfig(cmd: DBInit, _, _)) => c.copy(cmd.copy(skip = true)) },
 
-        opt[Map[String, Int]]("shard-num")
-          text "Override number of shards per collection. Comma-separated key-value pairs, e.g. 'collectionA=2,collectionB=3'."
-          validate (
-          _.values.collectFirst({
-            case v if v < 1 => failure(s"Shard number should be positive, but was $v")
-          }).getOrElse(success))
-          action {
-          case (m, c@AdminCLIConfig(cmd@DBInit(_, _, _, opts), _, _)) =>
-            c.copy(cmd.copy(options = opts.copy(numShards = m.mapKeys(CollectionDef.forName))))
-        },
+          opt[Map[String, Int]]("shard-num")
+            .text("Override number of shards per collection. Comma-separated key-value pairs, e.g. 'collectionA=2,collectionB=3'.")
+            .validate(_.values
+              .collectFirst { case v if v < 1 => failure(s"Shard number should be positive, but was $v") }
+              .getOrElse(success))
+            .action {
+              case (m, c@AdminCLIConfig(cmd@DBInit(_, _, _, opts), _, _)) =>
+                c.copy(cmd.copy(options = opts.copy(numShards = m.mapKeys(CollectionDef.forName))))
+            },
 
-        opt[Int]("shard-num-default")
-          text "Override default number of shards."
-          validate (v => if (v < 1) failure(s"Shard number should be positive, but was $v") else success)
-          action {
-          case (v, c@AdminCLIConfig(cmd@DBInit(_, _, _, opts), _, _)) =>
-            c.copy(cmd.copy(options = opts.copy(numShardsDefault = Some(v))))
-        },
+          opt[Int]("shard-num-default")
+            .text("Override default number of shards.")
+            .validate(v => if (v < 1) failure(s"Shard number should be positive, but was $v") else success)
+            .action {
+              case (v, c@AdminCLIConfig(cmd@DBInit(_, _, _, opts), _, _)) =>
+                c.copy(cmd.copy(options = opts.copy(numShardsDefault = Some(v))))
+            },
 
-        opt[Map[String, String]]("shard-keys")
-          text "Override shard keys per collection. Comma-separated key-value pairs, where value is a key name list separated by '+', e.g. 'collectionA=k1+k2,collectionB=k3'."
-          action {
-          case (m, c@AdminCLIConfig(cmd@DBInit(_, _, _, opts), _, _)) =>
-            c.copy(cmd.copy(options = opts.copy(shardKeys = m.map({
-              case (k, s) => CollectionDef.forName(k) -> s.split('+').map(_.trim).toSeq
-            }))))
-        },
+          opt[Map[String, String]]("shard-keys")
+            .text("Override shard keys per collection. Comma-separated key-value pairs, where value is a key name list separated by '+', e.g. 'collectionA=k1+k2,collectionB=k3'.")
+            .action {
+              case (m, c@AdminCLIConfig(cmd@DBInit(_, _, _, opts), _, _)) =>
+                c.copy(cmd.copy(options = opts.copy(shardKeys = m.map({
+                  case (k, s) => CollectionDef.forName(k) -> s.split('+').map(_.trim).toSeq
+                }))))
+            },
 
-        opt[String]("shard-keys-default")
-          text "Override default shard keys. Key names separated by '+' character, e.g. 'key1+key2+key3'."
-          action {
-          case (v, c@AdminCLIConfig(cmd@DBInit(_, _, _, opts), _, _)) =>
-            c.copy(cmd.copy(options = opts.copy(shardKeysDefault = Some(v.split('+').map(_.trim)))))
-        },
+          opt[String]("shard-keys-default")
+            .text("Override default shard keys. Key names separated by '+' character, e.g. 'key1+key2+key3'.")
+            .action {
+              case (v, c@AdminCLIConfig(cmd@DBInit(_, _, _, opts), _, _)) =>
+                c.copy(cmd.copy(options = opts.copy(shardKeysDefault = Some(v.split('+').map(_.trim)))))
+            },
 
-        opt[Map[String, Int]]("repl-factor")
-          text "Override replication factor per collection. Comma-separated key-value pairs, e.g. 'collectionA=2,collectionB=3'."
-          validate (
-          _.values.collectFirst({
-            case v if v < 1 => failure(s"Replication factor should be positive, but was $v")
-          }).getOrElse(success))
-          action {
-          case (m, c@AdminCLIConfig(cmd@DBInit(_, _, _, opts), _, _)) =>
-            c.copy(cmd.copy(options = opts.copy(replFactor = m.mapKeys(CollectionDef.forName))))
-        },
+          opt[Map[String, Int]]("repl-factor")
+            .text("Override replication factor per collection. Comma-separated key-value pairs, e.g. 'collectionA=2,collectionB=3'.")
+            .validate(_.values
+              .collectFirst { case v if v < 1 => failure(s"Replication factor should be positive, but was $v") }
+              .getOrElse(success))
+            .action {
+              case (m, c@AdminCLIConfig(cmd@DBInit(_, _, _, opts), _, _)) =>
+                c.copy(cmd.copy(options = opts.copy(replFactor = m.mapKeys(CollectionDef.forName))))
+            },
 
-        opt[Int]("repl-factor-default")
-          text "Override default replication factor."
-          validate (v => if (v < 1) failure(s"Replication factor should be positive, but was $v") else success)
-          action {
-          case (v, c@AdminCLIConfig(cmd@DBInit(_, _, _, opts), _, _)) =>
-            c.copy(cmd.copy(options = opts.copy(replFactorDefault = Some(v))))
-        },
+          opt[Int]("repl-factor-default")
+            .text("Override default replication factor.")
+            .validate(v => if (v < 1) failure(s"Replication factor should be positive, but was $v") else success)
+            .action {
+              case (v, c@AdminCLIConfig(cmd@DBInit(_, _, _, opts), _, _)) =>
+                c.copy(cmd.copy(options = opts.copy(replFactorDefault = Some(v))))
+            },
 
-        opt[Unit]("wait-for-sync")
-          text "Ensure the data is synchronized to disk before returning from a document CUD operation."
-          action { case (_, c@AdminCLIConfig(cmd@DBInit(_, _, _, opts), _, _)) => c.copy(cmd.copy(options = opts.copy(waitForSync = true))) })
-        children (this.dbCommandOptions: _*)
+          opt[Unit]("wait-for-sync")
+            .text("Ensure the data is synchronized to disk before returning from a document CUD operation.")
+            .action {
+              case (_, c@AdminCLIConfig(cmd@DBInit(_, _, _, opts), _, _)) =>
+                c.copy(cmd.copy(options = opts.copy(waitForSync = true)))
+            }
         )
+        .children(this.dbCommandOptions: _*)
 
       this.placeNewLine()
 
-      (cmd("db-upgrade")
-        action ((_, c) => c.copy(cmd = DBUpgrade()))
-        text "Upgrade Spline database"
-        children (this.dbCommandOptions: _*))
+      cmd("db-upgrade")
+        .action((_, c) => c.copy(cmd = DBUpgrade()))
+        .text("Upgrade Spline database")
+        .children(this.dbCommandOptions: _*)
 
       this.placeNewLine()
 
-      (cmd("db-exec")
-        action ((_, c) => c.copy(cmd = DBExec()))
-        text "Auxiliary actions mainly intended for development, testing etc."
-        children(
-        opt[Unit]("check-access")
-          text "Check access to the database"
-          action { case (_, c@AdminCLIConfig(cmd: DBExec, _, _)) => c.copy(cmd.addAction(CheckDBAccess)) },
-        opt[Unit]("foxx-reinstall")
-          text "Reinstall Foxx services"
-          action { case (_, c@AdminCLIConfig(cmd: DBExec, _, _)) => c.copy(cmd.addAction(FoxxReinstall)) },
-        opt[Unit]("indices-delete")
-          text "Delete indices"
-          action { case (_, c@AdminCLIConfig(cmd: DBExec, _, _)) => c.copy(cmd.addAction(IndicesDelete)) },
-        opt[Unit]("indices-create")
-          text "Create indices"
-          action { case (_, c@AdminCLIConfig(cmd: DBExec, _, _)) => c.copy(cmd.addAction(IndicesCreate)) },
-        opt[Unit]("search-views-delete")
-          text "Delete search views"
-          action { case (_, c@AdminCLIConfig(cmd: DBExec, _, _)) => c.copy(cmd.addAction(SearchViewsDelete)) },
-        opt[Unit]("search-views-create")
-          text "Create search views"
-          action { case (_, c@AdminCLIConfig(cmd: DBExec, _, _)) => c.copy(cmd.addAction(SearchViewsCreate)) },
-        opt[Unit]("search-analyzers-delete")
-          text "Delete search analyzers"
-          action { case (_, c@AdminCLIConfig(cmd: DBExec, _, _)) => c.copy(cmd.addAction(SearchAnalyzerDelete)) },
-        opt[Unit]("search-analyzers-create")
-          text "Create search analyzers"
-          action { case (_, c@AdminCLIConfig(cmd: DBExec, _, _)) => c.copy(cmd.addAction(SearchAnalyzerCreate)) })
-        children (this.dbCommandOptions: _*)
+      cmd("db-exec")
+        .action((_, c) => c.copy(cmd = DBExec()))
+        .text("Auxiliary actions mainly intended for development, testing etc.")
+        .children(
+          opt[Unit]("check-access")
+            .text("Check access to the database")
+            .action { case (_, c@AdminCLIConfig(cmd: DBExec, _, _)) => c.copy(cmd.addAction(CheckDBAccess)) },
+          opt[Unit]("foxx-reinstall")
+            .text("Reinstall Foxx services")
+            .action { case (_, c@AdminCLIConfig(cmd: DBExec, _, _)) => c.copy(cmd.addAction(FoxxReinstall)) },
+          opt[Unit]("indices-delete")
+            .text("Delete indices")
+            .action { case (_, c@AdminCLIConfig(cmd: DBExec, _, _)) => c.copy(cmd.addAction(IndicesDelete)) },
+          opt[Unit]("indices-create")
+            .text("Create indices")
+            .action { case (_, c@AdminCLIConfig(cmd: DBExec, _, _)) => c.copy(cmd.addAction(IndicesCreate)) },
+          opt[Unit]("search-views-delete")
+            .text("Delete search views")
+            .action { case (_, c@AdminCLIConfig(cmd: DBExec, _, _)) => c.copy(cmd.addAction(SearchViewsDelete)) },
+          opt[Unit]("search-views-create")
+            .text("Create search views")
+            .action { case (_, c@AdminCLIConfig(cmd: DBExec, _, _)) => c.copy(cmd.addAction(SearchViewsCreate)) },
+          opt[Unit]("search-analyzers-delete")
+            .text("Delete search analyzers")
+            .action { case (_, c@AdminCLIConfig(cmd: DBExec, _, _)) => c.copy(cmd.addAction(SearchAnalyzerDelete)) },
+          opt[Unit]("search-analyzers-create")
+            .text("Create search analyzers")
+            .action { case (_, c@AdminCLIConfig(cmd: DBExec, _, _)) => c.copy(cmd.addAction(SearchAnalyzerCreate)) }
         )
+        .children(this.dbCommandOptions: _*)
 
       checkConfig {
         case AdminCLIConfig(null, _, _) =>

--- a/admin/src/main/scala/za/co/absa/spline/admin/commands.scala
+++ b/admin/src/main/scala/za/co/absa/spline/admin/commands.scala
@@ -17,7 +17,7 @@ package za.co.absa.spline.admin
  */
 
 import za.co.absa.spline.admin.DBCommand._
-import za.co.absa.spline.persistence.{ArangoConnectionURL, AuxiliaryDBAction}
+import za.co.absa.spline.persistence.{ArangoConnectionURL, AuxiliaryDBAction, DatabaseCreateOptions}
 
 sealed trait Command
 
@@ -42,7 +42,8 @@ object DBCommand {
 case class DBInit(
   override val dbUrl: Url = null,
   force: Boolean = false,
-  skip: Boolean = false
+  skip: Boolean = false,
+  options: DatabaseCreateOptions = DatabaseCreateOptions()
 ) extends DBCommand {
   protected override type Self = DBInit
   protected override val selfCopy: DBCommandProps => Self = copy(_)

--- a/admin/src/test/scala/za/co/absa/spline/admin/AdminCLISpec.scala
+++ b/admin/src/test/scala/za/co/absa/spline/admin/AdminCLISpec.scala
@@ -20,6 +20,7 @@ import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatest.OneInstancePerTest
+import org.scalatest.OptionValues._
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.mockito.MockitoSugar
@@ -27,7 +28,8 @@ import za.co.absa.commons.scalatest.{ConsoleStubs, SystemExitFixture}
 import za.co.absa.spline.common.SplineBuildInfo
 import za.co.absa.spline.common.security.TLSUtils
 import za.co.absa.spline.persistence.OnDBExistsAction.{Drop, Fail, Skip}
-import za.co.absa.spline.persistence.{ArangoConnectionURL, ArangoManager, ArangoManagerFactory, OnDBExistsAction}
+import za.co.absa.spline.persistence.model.{EdgeDef, NodeDef}
+import za.co.absa.spline.persistence._
 
 import javax.net.ssl.SSLContext
 import scala.concurrent.Future
@@ -67,6 +69,7 @@ class AdminCLISpec
 
   {
     val connUrlCaptor: ArgumentCaptor[ArangoConnectionURL] = ArgumentCaptor.forClass(classOf[ArangoConnectionURL])
+    val dbOptionCaptor: ArgumentCaptor[DatabaseCreateOptions] = ArgumentCaptor.forClass(classOf[DatabaseCreateOptions])
     val actionFlgCaptor: ArgumentCaptor[OnDBExistsAction] = ArgumentCaptor.forClass(classOf[OnDBExistsAction])
     val sslCtxCaptor: ArgumentCaptor[Option[SSLContext]] = ArgumentCaptor.forClass(classOf[Option[SSLContext]])
 
@@ -75,7 +78,7 @@ class AdminCLISpec
       thenReturn arangoManagerMock)
 
     (when(
-      arangoManagerMock.initialize(actionFlgCaptor.capture))
+      arangoManagerMock.initialize(actionFlgCaptor.capture, dbOptionCaptor.capture))
       thenReturn Future.successful(true))
 
     (when(
@@ -108,6 +111,78 @@ class AdminCLISpec
     }
 
     behavior of "DB-Init"
+
+    it should "accept custom collection options" in assertingStdOut(include("DONE")) {
+      cli.exec(Array(
+        "db-init",
+        "--shard-num-default", "42",
+        "--shard-num", "executionPlan=3,progressOf=5",
+
+        "--shard-keys-default", "a+b+c",
+        "--shard-keys", "executionPlan=x+y,progressOf=z",
+
+        "--repl-factor-default", "55",
+        "--repl-factor", "executionPlan=7,progressOf=9",
+
+        "--wait-for-sync",
+
+        "arangodb://foo/bar"))
+
+      dbOptionCaptor.getValue.numShards(NodeDef.ExecutionPlan) should equal(3)
+      dbOptionCaptor.getValue.numShards(EdgeDef.ProgressOf) should equal(5)
+      dbOptionCaptor.getValue.numShardsDefault should equal(Some(42))
+
+      dbOptionCaptor.getValue.shardKeys(NodeDef.ExecutionPlan) should contain theSameElementsInOrderAs Seq("x", "y")
+      dbOptionCaptor.getValue.shardKeys(EdgeDef.ProgressOf) should contain theSameElementsInOrderAs Seq("z")
+      dbOptionCaptor.getValue.shardKeysDefault should be(defined)
+      dbOptionCaptor.getValue.shardKeysDefault.value should contain theSameElementsInOrderAs Seq("a", "b", "c")
+
+      dbOptionCaptor.getValue.replFactor(NodeDef.ExecutionPlan) should equal(7)
+      dbOptionCaptor.getValue.replFactor(EdgeDef.ProgressOf) should equal(9)
+      dbOptionCaptor.getValue.replFactorDefault should equal(Some(55))
+
+      dbOptionCaptor.getValue.waitForSync should equal(true)
+    }
+
+    it should "validate '--shard-num'" in {
+      captureExitStatus(cli.exec(Array("db-init", "--shard-num", "operation=1", "arangodb://foo/bar"))) should be(0)
+
+      captureStdErr(
+        captureExitStatus(
+          cli.exec(Array("db-init", "--shard-num", "operation=0", "arangodb://foo/bar"))
+        ) should be(1)
+      ) should include("Shard number should be positive")
+    }
+
+    it should "validate '--shard-num-default'" in {
+      captureExitStatus(cli.exec(Array("db-init", "--shard-num-default", "1", "arangodb://foo/bar"))) should be(0)
+
+      captureStdErr(
+        captureExitStatus(
+          cli.exec(Array("db-init", "--shard-num-default", "0", "arangodb://foo/bar"))
+        ) should be(1)
+      ) should include("Shard number should be positive")
+    }
+
+    it should "validate '--repl-factor'" in {
+      captureExitStatus(cli.exec(Array("db-init", "--repl-factor", "operation=1", "arangodb://foo/bar"))) should be(0)
+
+      captureStdErr(
+        captureExitStatus(
+          cli.exec(Array("db-init", "--repl-factor", "operation=0", "arangodb://foo/bar"))
+        ) should be(1)
+      ) should include("Replication factor should be positive")
+    }
+
+    it should "validate '--repl-factor-default'" in {
+      captureExitStatus(cli.exec(Array("db-init", "--repl-factor-default", "1", "arangodb://foo/bar"))) should be(0)
+
+      captureStdErr(
+        captureExitStatus(
+          cli.exec(Array("db-init", "--repl-factor-default", "0", "arangodb://foo/bar"))
+        ) should be(1)
+      ) should include("Replication factor should be positive")
+    }
 
     it should "initialize database" in assertingStdOut(include("DONE")) {
       cli.exec(Array("db-init", "arangodb://foo/bar"))

--- a/commons/src/main/scala/za/co/absa/spline/common/CollectionUtils.scala
+++ b/commons/src/main/scala/za/co/absa/spline/common/CollectionUtils.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2022 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.spline.common
+
+object CollectionUtils {
+
+  object Implicits {
+
+    implicit class MapOps[K, V](val map: Map[K, V]) extends AnyVal {
+      def mapKeys[L](f: K => L): Map[L, V] = map.map {
+        case (a, b) => (f(a), b)
+      }
+    }
+  }
+}

--- a/persistence/src/main/scala/za/co/absa/spline/persistence/AutoClosingArangoManagerProxy.scala
+++ b/persistence/src/main/scala/za/co/absa/spline/persistence/AutoClosingArangoManagerProxy.scala
@@ -27,8 +27,8 @@ class AutoClosingArangoManagerProxy(
   (implicit val ex: ExecutionContext)
   extends ArangoManager {
 
-  override def initialize(onExistsAction: OnDBExistsAction): Future[Boolean] =
-    withManager(_.initialize(onExistsAction))
+  override def initialize(onExistsAction: OnDBExistsAction, options: DatabaseCreateOptions): Future[Boolean] =
+    withManager(_.initialize(onExistsAction, options))
 
   override def upgrade(): Future[Unit] =
     withManager(_.upgrade())

--- a/persistence/src/main/scala/za/co/absa/spline/persistence/DatabaseCreateOptions.scala
+++ b/persistence/src/main/scala/za/co/absa/spline/persistence/DatabaseCreateOptions.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2022 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.spline.persistence
+
+import za.co.absa.spline.persistence.model.CollectionDef
+
+case class DatabaseCreateOptions(
+
+  numShards: Map[CollectionDef, Int] = Map.empty,
+  numShardsDefault: Option[Int] = None,
+
+  shardKeys: Map[CollectionDef, Seq[String]] = Map.empty,
+  shardKeysDefault: Option[Seq[String]] = None,
+
+  replFactor: Map[CollectionDef, Int] = Map.empty,
+  replFactorDefault: Option[Int] = None,
+
+  waitForSync: Boolean = false
+)


### PR DESCRIPTION
Add the following options to the `db-init` command of the _Admin CLI_:
```
  --shard-num <value>      Override number of shards per collection. Comma-separated key-value pairs, e.g. 'collectionA=2,collectionB=3'.
  --shard-num-default <value>
                           Override default number of shards.
  --shard-keys <value>     Override shard keys per collection. Comma-separated key-value pairs, where value is a key name list separated by '+', e.g. 'collectionA=k1+k2,collectionB=k3'.
  --shard-keys-default <value>
                           Override default shard keys. Key names separated by '+' character, e.g. 'key1+key2+key3'.
  --repl-factor <value>    Override replication factor per collection. Comma-separated key-value pairs, e.g. 'collectionA=2,collectionB=3'.
  --repl-factor-default <value>
                           Override default replication factor.
  --wait-for-sync          Ensure the data is synchronized to disk before returning from a document CUD operation.

```

resolves #1048 