### PR TITLE
spline #1076 fix "must not specify _key"

### DIFF
--- a/persistence/src/main/scala/za/co/absa/spline/persistence/ArangoManager.scala
+++ b/persistence/src/main/scala/za/co/absa/spline/persistence/ArangoManager.scala
@@ -67,7 +67,7 @@ class ArangoManagerImpl(
         Future.successful(false)
       } else for {
         _ <- deleteDbIfRequested(db, onExistsAction == Drop)
-        _ <- db.create().toScala
+        _ <- createDb(db)
         _ <- createCollections(db, options)
         _ <- createAQLUserFunctions(db)
         _ <- createFoxxServices()
@@ -136,6 +136,11 @@ class ArangoManagerImpl(
       }
       else Future.successful({})
     } yield {}
+  }
+
+  private def createDb(db: ArangoDatabaseAsync) = {
+    log.info(s"Create database: ${db.dbName}")
+    db.create().toScala
   }
 
   private def createCollections(db: ArangoDatabaseAsync, options: DatabaseCreateOptions) = {

--- a/persistence/src/main/scala/za/co/absa/spline/persistence/model/entities.scala
+++ b/persistence/src/main/scala/za/co/absa/spline/persistence/model/entities.scala
@@ -86,10 +86,11 @@ object DBVersion {
 case class DataSource(
   uri: DataSource.Uri,
   name: DataSource.Name,
-  override val _key: DataSource.Key,
   lastWriteDetails: Option[Progress]
 ) extends Vertex with RootEntity {
-  def this() = this(null, null, null, null)
+  override val _key: DataSource.Key = null
+
+  def this() = this(null, null, null)
 }
 
 object DataSource {
@@ -99,9 +100,11 @@ object DataSource {
 
   private val NameRegexp = "([^/]+)/*$".r
 
-  def getName(uri: Uri): Name = {
+  private[persistence] def getName(uri: Uri): Name = {
     NameRegexp.findFirstMatchIn(uri).map(_.group(1)).getOrElse("")
   }
+
+  def apply(uri: Uri): DataSource = DataSource(uri, getName(uri), None)
 }
 
 /**

--- a/producer-services/src/main/scala/za/co/absa/spline/producer/service/model/ExecutionPlanPersistentModel.scala
+++ b/producer-services/src/main/scala/za/co/absa/spline/producer/service/model/ExecutionPlanPersistentModel.scala
@@ -35,9 +35,6 @@ case class ExecutionPlanPersistentModel(
   uses: Seq[Edge], // ... attribute or expression
   produces: Seq[Edge], // ... attribute
 
-  // data source
-  dataSources: Seq[DataSource],
-
   // schema
   schemas: Seq[Schema],
   consistsOf: Seq[Edge], // ... attributes

--- a/producer-services/src/main/scala/za/co/absa/spline/producer/service/repo/ExecutionProducerRepositoryImpl.scala
+++ b/producer-services/src/main/scala/za/co/absa/spline/producer/service/repo/ExecutionProducerRepositoryImpl.scala
@@ -29,7 +29,6 @@ import za.co.absa.spline.producer.service.UUIDCollisionDetectedException
 import za.co.absa.spline.producer.service.model.{ExecutionEventKeyCreator, ExecutionPlanPersistentModel, ExecutionPlanPersistentModelBuilder}
 
 import scala.compat.java8.FutureConverters._
-import scala.compat.java8.StreamConverters._
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.control.NonFatal
 
@@ -52,18 +51,23 @@ class ExecutionProducerRepositoryImpl @Autowired()(db: ArangoDatabaseAsync) exte
       Map("key" -> executionPlan.id)
     )
 
-    val eventualPersistedDSKeyByURI: Future[Map[DataSource.Uri, DataSource.Key]] = db.queryAs[DataSource](
-      s"""
-         |WITH ${NodeDef.DataSource.name}
-         |FOR ds IN ${NodeDef.DataSource.name}
-         |    FILTER ds.uri IN @refURIs
-         |    RETURN KEEP(ds, ['_key', 'uri'])
-         |    """.stripMargin,
-      Map("refURIs" -> executionPlan.dataSources.toArray)
-    ).map(_.streamRemaining.toScala.map(ds => ds.uri -> ds._key).toMap)
+    val eventualPersistedDataSources: Future[Seq[DataSource]] = {
+      val dataSources: Set[DataSource] = executionPlan.dataSources.map(DataSource.apply)
+      db.queryStream[DataSource](
+        s"""
+           |WITH ${NodeDef.DataSource.name}
+           |FOR ds IN @dataSources
+           |    UPSERT { uri: ds.uri }
+           |        INSERT KEEP(ds, ['_created', 'uri', 'name'])
+           |        UPDATE {} IN ${NodeDef.DataSource.name}
+           |        RETURN KEEP(NEW, ['_key', 'uri'])
+           |    """.stripMargin,
+        Map("dataSources" -> dataSources.toArray)
+      )
+    }
 
     for {
-      persistedDSKeyByURI <- eventualPersistedDSKeyByURI
+      persistedDSKeyByURI <- eventualPersistedDataSources
       maybeExistingDiscriminatorOpt <- eventualMaybeExistingDiscriminatorOpt
       _ <- maybeExistingDiscriminatorOpt match {
         case Some(existingDiscriminatorOrNull) =>
@@ -100,10 +104,10 @@ object ExecutionProducerRepositoryImpl {
 
   private def createInsertTransaction(
     executionPlan: apiModel.ExecutionPlan,
-    persistedDSKeyByURI: Map[DataSource.Uri, DataSource.Key]
+    persistedDataSources: Seq[DataSource]
   ) = {
     val eppm: ExecutionPlanPersistentModel =
-      ExecutionPlanPersistentModelBuilder.toPersistentModel(executionPlan, persistedDSKeyByURI)
+      ExecutionPlanPersistentModelBuilder.toPersistentModel(executionPlan, persistedDataSources)
 
     new TxBuilder()
       // execution plan
@@ -120,9 +124,6 @@ object ExecutionProducerRepositoryImpl {
       .addQuery(InsertQuery(EdgeDef.Emits, eppm.emits))
       .addQuery(InsertQuery(EdgeDef.Uses, eppm.uses))
       .addQuery(InsertQuery(EdgeDef.Produces, eppm.produces))
-
-      // data source
-      .addQuery(InsertQuery(NodeDef.DataSource, eppm.dataSources))
 
       // schema
       .addQuery(InsertQuery(NodeDef.Schema, eppm.schemas))


### PR DESCRIPTION
When using a custom shard key (`uri`) for a collection (`dataSource`) the primary key [must](https://www.arangodb.com/docs/stable/architecture-deployment-modes-cluster-sharding.html#configuring-shards) be generated by the database.
To achieve that, all data sources referenced by an execution plan that is being inserted, are now _upserted_ into the DB first, their persistent IDs are obtained, and then the rest of the execution plan persistent object is created using those IDs.