### PR TITLE
Forward Lineage

### DIFF
--- a/consumer-rest-core/src/main/scala/za/co/absa/spline/consumer/rest/controller/LineageOverviewController.scala
+++ b/consumer-rest-core/src/main/scala/za/co/absa/spline/consumer/rest/controller/LineageOverviewController.scala
@@ -53,4 +53,28 @@ class LineageOverviewController @Autowired()(val repo: LineageRepository) {
     maxDepth: Int
   ): Future[LineageOverview] =
     repo.lineageOverviewForExecutionEvent(eventId, maxDepth)
+
+  @GetMapping(Array("/forward-lineage-overview"))
+  @ApiOperation(
+    value = "Get execution event lineage overview",
+    notes =
+      """
+        Returns a forward lineage overview for a given execution event.
+        The graph consists of nodes of two types: data sources and executed jobs.
+        The lineage describes the forward data flow only, that is the data flow that has impacted and
+        is observed by the given execution event (at the time of the event)
+      """
+  )
+  def forwardLineageOverview(
+                              @ApiParam("Execution event ID")
+                              @RequestParam("eventId")
+                              eventId: String,
+
+                              @ApiParam(
+                                value = "Max depth of the graph. ([Source] -> [App] -> [Target]) is considered one level",
+                                example = "5")
+                              @RequestParam(name = "maxDepth", defaultValue = "5")
+                              maxDepth: Int
+                            ): Future[LineageOverview] =
+    repo.forwardLineageOverviewForExecutionEvent(eventId, maxDepth)
 }

--- a/consumer-services/src/main/scala/za/co/absa/spline/consumer/service/repo/LineageRepository.scala
+++ b/consumer-services/src/main/scala/za/co/absa/spline/consumer/service/repo/LineageRepository.scala
@@ -23,4 +23,7 @@ trait LineageRepository {
 
   def lineageOverviewForExecutionEvent(eventId: WriteEventInfo.Id, maxDepth: Int)
     (implicit ec: ExecutionContext): Future[LineageOverview]
+
+  def forwardLineageOverviewForExecutionEvent(eventId: WriteEventInfo.Id, maxDepth: Int)
+                                             (implicit ec: ExecutionContext): Future[LineageOverview]
 }

--- a/consumer-services/src/main/scala/za/co/absa/spline/consumer/service/repo/LineageRepositoryImpl.scala
+++ b/consumer-services/src/main/scala/za/co/absa/spline/consumer/service/repo/LineageRepositoryImpl.scala
@@ -40,4 +40,16 @@ class LineageRepositoryImpl @Autowired()(db: ArangoDatabaseAsync) extends Lineag
           if cond(ce.getCause)({ case ae: ArangoDBException => ae.getResponseCode == 404 }) =>
           throw new NoSuchElementException(s"Event ID: $eventId")
       })
+
+  override def forwardLineageOverviewForExecutionEvent(eventId: WriteEventInfo.Id, maxDepth: Int)(implicit ec: ExecutionContext): Future[LineageOverview] =
+    db
+      .route(s"/spline_forward/events/$eventId/lineage-overview-b/$maxDepth")
+      .get()
+      .toScala
+      .map(resp => db.util().deserialize[LineageOverview](resp.getBody, classOf[LineageOverview]))
+      .recover({
+        case ce: CompletionException
+          if cond(ce.getCause)({ case ae: ArangoDBException => ae.getResponseCode == 404 }) =>
+          throw new NoSuchElementException(s"Event ID: $eventId")
+      })
 }

--- a/persistence/src/main/resources/foxx/spline_forward/index.js
+++ b/persistence/src/main/resources/foxx/spline_forward/index.js
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2020 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+const createRouter = require('@arangodb/foxx/router');
+const joi = require('joi');
+const {lineageOverview} = require('./services/lineage-overview');
+
+const router = createRouter();
+module.context.use(router);
+router
+    .get('/events/:eventKey/lineage-overview-b/:maxDepth',
+        (req, res) => {
+            const eventKey = req.pathParams.eventKey;
+            const maxDepth = req.pathParams.maxDepth;
+            const overview = lineageOverview(eventKey, maxDepth);
+            if (overview) {
+                res.send(overview);
+            } else {
+                res.status(404);
+            }
+        })
+    .pathParam('eventKey', joi.string().min(1).required(), 'Execution Event UUID')
+    .pathParam('maxDepth', joi.number().integer().min(0).required(), 'Max depth of traversing in terms of [Data Source] -> [Execution Plan] pairs')
+    .response(['application/json'], 'Lineage overview graph')
+    .summary('Execution event end-to-end lineage overview')
+    .description('Builds a lineage of the data produced by the given execution event');

--- a/persistence/src/main/resources/foxx/spline_forward/manifest.json
+++ b/persistence/src/main/resources/foxx/spline_forward/manifest.json
@@ -1,0 +1,6 @@
+{
+  "engines": {
+    "arangodb": "^3.0.0"
+  },
+  "main": "index.js"
+}

--- a/persistence/src/main/resources/foxx/spline_forward/services/lineage-overview.js
+++ b/persistence/src/main/resources/foxx/spline_forward/services/lineage-overview.js
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2020 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+"use strict";
+const {db, aql} = require('@arangodb');
+const {memoize} = require('../utils/common');
+const {GraphBuilder} = require('../utils/graph');
+const {observedReadsByWrite} = require('./observed-reads-by-write');
+
+/**
+ * Return a high-level forward lineage overview of the given write event.
+ *
+ * @param eventKey write event key
+ * @param maxDepth maximum number of job nodes in any path of the resulted graph (excluding cycles).
+ * It shows how far the traversal should looks for the lineage.
+ * @returns za.co.absa.spline.consumer.service.model.LineageOverview
+ */
+function forwardLineageOverview(eventKey, maxDepth) {
+
+    const executionEvent = db._query(aql`
+        WITH progress
+        RETURN FIRST(FOR p IN progress FILTER p._key == ${eventKey} RETURN p)
+    `).next();
+
+    const targetDataSource = executionEvent && db._query(aql`
+        WITH progress, progressOf, executionPlan, affects, dataSource
+        RETURN FIRST(FOR ds IN 2 OUTBOUND ${executionEvent} progressOf, affects RETURN ds)
+    `).next();
+
+    const lineageGraph = eventForwardLineageOverviewGraph(executionEvent, maxDepth);
+
+    return lineageGraph && {
+        "info": {
+            "timestamp": executionEvent.timestamp,
+            "applicationId": executionEvent.extra.appId,
+            "targetDataSourceId": targetDataSource._key
+        },
+        "graph": {
+            "depthRequested": maxDepth,
+            "depthComputed": lineageGraph.depth || -1,
+            "nodes": lineageGraph.vertices,
+            "edges": lineageGraph.edges
+        }
+    }
+}
+
+function eventForwardLineageOverviewGraph(startEvent, maxDepth) {
+    if (!startEvent || maxDepth < 0) {
+        return null;
+    }
+
+    const startSource = db._query(aql`
+        WITH progress, progressOf, executionPlan, affects, dataSource
+        FOR ds IN 2 OUTBOUND ${startEvent} progressOf, affects 
+            LIMIT 1
+            RETURN {
+                "_id": ds._key,
+                "_class": "za.co.absa.spline.consumer.service.model.DataSourceNode",
+                "name": ds.uri
+            }
+        `
+    ).next();
+
+    const graphBuilder = new GraphBuilder([startSource]);
+
+    const collectPartialGraphForEvent = event => {
+        const partialGraph = db._query(aql`
+            WITH progress, progressOf, executionPlan, affects, depends, dataSource
+
+            LET exec = FIRST(FOR ex IN 1 OUTBOUND ${event} progressOf RETURN ex)
+            LET affectedDs = FIRST(FOR v IN 1 OUTBOUND exec affects RETURN v)
+            LET affectedDsEdge = FIRST(FOR v, e IN 1 OUTBOUND exec affects RETURN e)
+            LET rdsWithInEdges = (FOR ds, e IN 1 OUTBOUND exec depends RETURN [ds, e])
+            LET readSources = rdsWithInEdges[*][0]
+            LET readDsEdges = rdsWithInEdges[*][1]
+            
+            LET vertices = (
+                FOR vert IN APPEND(APPEND(readSources, exec),affectedDs)
+                    LET vertType = SPLIT(vert._id, '/')[0]
+                    RETURN vertType == "dataSource"
+                        ? {
+                            "_id": vert._key,
+                            "_class": "za.co.absa.spline.consumer.service.model.DataSourceNode",
+                            "name": vert.uri
+                        }
+                        : MERGE(KEEP(vert, ["systemInfo", "agentInfo"]), {
+                            "_id": vert._key,
+                            "_class": "za.co.absa.spline.consumer.service.model.ExecutionNode",
+                            "name": vert.name || ""
+                        })
+            )
+            
+            LET edges = (
+                FOR edge IN APPEND(readDsEdges, affectedDsEdge)
+                    LET edgeType = SPLIT(edge._id, '/')[0]
+                    LET exKey = SPLIT(edge._from, '/')[1]
+                    LET dsKey = SPLIT(edge._to, '/')[1]
+                    RETURN {
+                        "source": edgeType == "depends" ? dsKey : exKey,
+                        "target": edgeType == "affects" ? dsKey : exKey
+                    }
+            )
+            
+            RETURN {vertices, edges}
+        `).next();
+
+        graphBuilder.add(partialGraph);
+    };
+
+    const traverse = memoize(e => e._id, (event, depth) => {
+        let remainingDepth = depth - 1;
+        if (depth > 1) {
+            observedReadsByWrite(event)
+                .forEach(writeEvent => {
+                    const remainingDepth_i = traverse(writeEvent, depth - 1);
+                    remainingDepth = Math.min(remainingDepth, remainingDepth_i);
+                })
+        }
+
+        collectPartialGraphForEvent(event);
+
+        return remainingDepth;
+    });
+
+    const remainingDepth = maxDepth > 0 ? traverse(startEvent, maxDepth) : 0;
+    const resultedGraph = graphBuilder.graph();
+
+    return {
+        depth: maxDepth - remainingDepth,
+        vertices: resultedGraph.vertices,
+        edges: resultedGraph.edges
+    }
+}
+
+module.exports = {
+    forwardLineageOverview
+}
+

--- a/persistence/src/main/resources/foxx/spline_forward/services/observed-reads-by-write.js
+++ b/persistence/src/main/resources/foxx/spline_forward/services/observed-reads-by-write.js
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+const {db, aql} = require('@arangodb');
+
+/**
+ * Returns a list of execution events which reads are visible from a write of the given execution event
+ *
+ * @param readEvent za.co.absa.spline.persistence.model.Progress
+ * @returns za.co.absa.spline.persistence.model.Progress[]
+ */
+function observedReadsByWrite(writeEvent) {
+    return writeEvent && db._query(aql`
+        WITH progress, progressOf, executionPlan,affects, depends,dataSource
+        LET writeTime = ${writeEvent}.timestamp
+        FOR rds IN 2 OUTBOUND ${writeEvent} progressOf, affects
+        	LET allObservedEvents =
+                (FOR e IN 2 INBOUND rds depends,progressOf
+                    FILTER e.timestamp > writeTime
+                    	RETURN e
+                )
+            FOR e IN allObservedEvents RETURN e
+    `).toArray();
+}
+
+module.exports = {
+    observedReadsByWrite
+};

--- a/persistence/src/main/resources/foxx/spline_forward/utils/common.js
+++ b/persistence/src/main/resources/foxx/spline_forward/utils/common.js
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+"use strict";
+
+/**
+ * Returns a memoized function that is based on two provided ones - the key and value functions respectively.
+ * The signature of the provided functions must be identical, and the resulting memoized function will have the same signature.
+ * When the resulting function is invoked the key function is first called to get the caching key. The value function is only
+ * called when there's no previously cached value for the key. Otherwise the cached value is returned.
+ * @param keyFn a key function
+ * @param valFn a value function
+ * @returns memoized function with the same signature as _keyFn_ and _valueFn_
+ */
+function memoize(keyFn, valFn) {
+    const cache = new Map();
+    return function () {
+        const key = keyFn.apply(this, arguments);
+        if (cache.has(key)) {
+            return cache.get(key);
+        } else {
+            const value = valFn.apply(this, arguments);
+            cache.set(key, value);
+            return value;
+        }
+    }
+}
+
+module.exports = {
+    memoize,
+}

--- a/persistence/src/main/resources/foxx/spline_forward/utils/graph.js
+++ b/persistence/src/main/resources/foxx/spline_forward/utils/graph.js
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2020 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+"use strict";
+
+class DistinctCollector {
+    constructor(keyFn, initialValues) {
+        this.keyFn = keyFn;
+        this.keys = new Set((initialValues || []).map(v => keyFn(v)));
+        this.vals = initialValues || [];
+    }
+
+    add(o) {
+        const k = this.keyFn(o);
+        if (!this.keys.has(k)) {
+            this.keys.add(k);
+            this.vals.push(o);
+        }
+    }
+}
+
+class GraphBuilder {
+    constructor(vertices, edges) {
+        this.vertexCollector = new DistinctCollector(v => v._id, vertices);
+        this.edgeCollector = new DistinctCollector(e => `${e.source}:${e.target}`, edges);
+    }
+
+    add(pGraph) {
+        pGraph.vertices.forEach(v => this.vertexCollector.add(v));
+        pGraph.edges.forEach(e => this.edgeCollector.add(e));
+    }
+
+    graph() {
+        return {
+            vertices: this.vertexCollector.vals,
+            edges: this.edgeCollector.vals
+        }
+    }
+}
+
+module.exports = {
+    GraphBuilder
+}


### PR DESCRIPTION
Following up on the discussion: https://github.com/AbsaOSS/spline/discussions/1081
I created a new foxx service which gives the forward lineage for a given write event. I was able to visualise the forward lineage on the lineage overview page.

Attaching the screenshot of the same.

<img width="1561" alt="forwardLineage" src="https://user-images.githubusercontent.com/10565421/179474315-34a2861a-8e2b-4fe3-8960-54cfabf89076.png">

The PR is for the backend change for the forward lineage.
