### PR TITLE
curl added to rest-gateway dockerfile

### DIFF
--- a/rest-gateway/Dockerfile
+++ b/rest-gateway/Dockerfile
@@ -18,6 +18,8 @@ ARG DOCKER_BASE_IMAGE_PREFIX=
 
 FROM "$DOCKER_BASE_IMAGE_PREFIX"tomcat:9-jre11-openjdk-slim-buster
 
+RUN apt-get update && apt-get install curl -y
+
 LABEL \
     vendor="ABSA" \
     copyright="2019 ABSA Group Limited" \


### PR DESCRIPTION
This PR installs `curl` inside Spline's `rest-gateway` docker image in order to correctly use it during the docker-compose orchestration.

At least on my machine (Win 10 box), curl was not present and the orchestration has been failing due to this fact