### PR TITLE
spline #1116 TypeError: Cannot read property 'curVal' of null

### DIFF
--- a/arangodb-foxx-services/src/main/services/store.ts
+++ b/arangodb-foxx-services/src/main/services/store.ts
@@ -47,7 +47,9 @@ function insertMany<T extends Record<string, any>>(docs: T[], colName: Collectio
 
 function getDocByKey<T extends Document>(colName: CollectionName, key: DocumentKey, rtxInfo: ReadTxInfo = undefined): T {
     const doc = <T & TxAwareDocument>db._document(`${colName}/${key}`)
-    return doc && rtxInfo && isVisibleFromTx(rtxInfo, doc) ? doc : null
+    return doc && rtxInfo && !isVisibleFromTx(rtxInfo, doc)
+        ? null // the doc is found, but is not visible from inside the given read transaction.
+        : doc  // otherwise return the doc, or null if it's not there.
 }
 
 function deleteByKey(colName: CollectionName, key: DocumentKey): DocumentMetadata {


### PR DESCRIPTION
fixes #1116 

The `Store.getDocByKey(colName, key, rtxInfo)` function should, when no _read transaction info_ provided (meaning the call is made outside of any read transaction and no transaction isolation level is required), return the found document unconditionally.