### PR TITLE
Bugfix/spline 1122 labels not working

### DIFF
--- a/build/parent-pom/pom.xml
+++ b/build/parent-pom/pom.xml
@@ -384,7 +384,7 @@
             <dependency>
                 <groupId>za.co.absa.commons</groupId>
                 <artifactId>commons_${scala.compat.version}</artifactId>
-                <version>1.0.2</version>
+                <version>1.3.0</version>
             </dependency>
 
             <!-- Apache Commons -->

--- a/commons/src/main/scala/za/co/absa/spline/common/rest/RESTClientApacheHttpImpl.scala
+++ b/commons/src/main/scala/za/co/absa/spline/common/rest/RESTClientApacheHttpImpl.scala
@@ -37,7 +37,7 @@ class RESTClientApacheHttpImpl(
   (implicit ec: ExecutionContext)
   extends RESTClient {
 
-  import za.co.absa.commons.lang.OptionImplicits._
+  import za.co.absa.commons.lang.extensions.AnyExtension._
 
   override def get(path: String): Future[String] = execHttp {
     baseUri => new HttpGet(s"$baseUri/$path")

--- a/consumer-rest-core/src/main/scala/za/co/absa/spline/consumer/rest/controller/AbstractExecutionEventsController.scala
+++ b/consumer-rest-core/src/main/scala/za/co/absa/spline/consumer/rest/controller/AbstractExecutionEventsController.scala
@@ -25,7 +25,8 @@ class AbstractExecutionEventsController(
   repo: AbstractExecutionEventRepository
 ) {
 
-  import za.co.absa.commons.lang.OptionImplicits._
+  import za.co.absa.commons.lang.extensions.NonOptionExtension._
+  import za.co.absa.commons.lang.extensions.StringExtension._
 
   import scala.concurrent.ExecutionContext.Implicits._
 

--- a/consumer-rest-core/src/main/scala/za/co/absa/spline/consumer/rest/controller/LabelsController.scala
+++ b/consumer-rest-core/src/main/scala/za/co/absa/spline/consumer/rest/controller/LabelsController.scala
@@ -31,7 +31,7 @@ class LabelsController @Autowired()(
   val repo: LabelRepository
 ) {
 
-  import za.co.absa.commons.lang.OptionImplicits._
+  import za.co.absa.commons.lang.extensions.StringExtension._
 
   import scala.concurrent.ExecutionContext.Implicits._
 

--- a/consumer-services/src/main/scala/za/co/absa/spline/consumer/service/repo/DataSourceRepositoryImpl.scala
+++ b/consumer-services/src/main/scala/za/co/absa/spline/consumer/service/repo/DataSourceRepositoryImpl.scala
@@ -34,7 +34,7 @@ import scala.concurrent.{ExecutionContext, Future}
 @Repository
 class DataSourceRepositoryImpl @Autowired()(db: ArangoDatabaseAsync) extends DataSourceRepository {
 
-  import za.co.absa.commons.lang.OptionImplicits._
+  import za.co.absa.commons.lang.extensions.AnyExtension._
 
   override def getTimestampRange(
     asAtTime: Long,
@@ -89,10 +89,9 @@ class DataSourceRepositoryImpl @Autowired()(db: ArangoDatabaseAsync) extends Dat
         "includeNoWrite" -> Boolean.box(writeAppendOptions.contains(None)),
         "applicationId" -> maybeApplicationId.orNull,
         "dataSourceUri" -> maybeDataSourceUri.orNull
-      ).optionally(
-        _.updated("lblValues", _: Seq[Array[Label.Value]]),
-        lblValues.toSeq.asOption
-      )
+      ).when(lblValues.nonEmpty) {
+        _.updated("lblValues", lblValues)
+      }
     ).map { case Array(from, to) => from -> to }
   }
 
@@ -171,10 +170,9 @@ class DataSourceRepositoryImpl @Autowired()(db: ArangoDatabaseAsync) extends Dat
         "includeNoWrite" -> Boolean.box(writeAppendOptions.contains(None)),
         "applicationId" -> maybeWriteApplicationId.orNull,
         "dataSourceUri" -> maybeDataSourceUri.orNull
-      ).optionally(
-        _.updated("lblValues", _: Seq[Array[Label.Value]]),
-        lblValues.toSeq.asOption
-      ),
+      ).when(lblValues.nonEmpty) {
+        _.updated("lblValues", lblValues)
+      },
       new AqlQueryOptions().fullCount(true)
     ).map {
       arangoCursorAsync =>

--- a/consumer-services/src/main/scala/za/co/absa/spline/consumer/service/repo/ExecutionEventRepositoryImpl.scala
+++ b/consumer-services/src/main/scala/za/co/absa/spline/consumer/service/repo/ExecutionEventRepositoryImpl.scala
@@ -32,7 +32,7 @@ import scala.concurrent.{ExecutionContext, Future}
 @Repository
 class ExecutionEventRepositoryImpl @Autowired()(db: ArangoDatabaseAsync) extends ExecutionEventRepository {
 
-  import za.co.absa.commons.lang.OptionImplicits._
+  import za.co.absa.commons.lang.extensions.AnyExtension._
 
   override def getTimestampRange(
     asAtTime: Long,
@@ -84,10 +84,9 @@ class ExecutionEventRepositoryImpl @Autowired()(db: ArangoDatabaseAsync) extends
         "writeAppends" -> (if (writeAppendOptions.isEmpty) null else writeAppendOptions.flatten.map(Boolean.box)),
         "applicationId" -> maybeApplicationId.orNull,
         "dataSourceUri" -> maybeDataSourceUri.orNull
-      ).optionally(
-        _.updated("lblValues", _: Seq[Array[Label.Value]]),
-        lblValues.toSeq.asOption
-      ),
+      ).when(lblValues.nonEmpty) {
+        _.updated("lblValues", lblValues)
+      },
     ).map { case Array(from, to) => from -> to }
   }
 
@@ -163,10 +162,9 @@ class ExecutionEventRepositoryImpl @Autowired()(db: ArangoDatabaseAsync) extends
         "writeAppends" -> (if (writeAppendOptions.isEmpty) null else writeAppendOptions.flatten.map(Boolean.box)),
         "applicationId" -> maybeApplicationId.orNull,
         "dataSourceUri" -> maybeDataSourceUri.orNull
-      ).optionally(
-        _.updated("lblValues", _: Seq[Array[Label.Value]]),
-        lblValues.toSeq.asOption
-      ),
+      ).when(lblValues.nonEmpty) {
+        _.updated("lblValues", lblValues)
+      },
       new AqlQueryOptions().fullCount(true)
     ).map {
       arangoCursorAsync =>

--- a/persistence/src/main/scala/za/co/absa/spline/persistence/ArangoConnectionURL.scala
+++ b/persistence/src/main/scala/za/co/absa/spline/persistence/ArangoConnectionURL.scala
@@ -17,15 +17,16 @@
 package za.co.absa.spline.persistence
 
 import org.apache.commons.lang3.StringUtils.trimToNull
-import za.co.absa.commons.lang.OptionImplicits.StringWrapper
 import za.co.absa.spline.persistence.ArangoConnectionURL.ArangoSecureDbScheme
 
 import java.net.MalformedURLException
+import scala.collection.mutable
 import scala.util.matching.Regex
 
 case class ArangoConnectionURL(scheme: String, user: Option[String], password: Option[String], hosts: Seq[(String, Int)], dbName: String) {
 
-  import za.co.absa.commons.lang.OptionImplicits._
+  import za.co.absa.commons.lang.extensions.AnyExtension._
+  import za.co.absa.commons.lang.extensions.StringExtension._
 
   require(user.isDefined || password.isEmpty, "user cannot be blank if password is specified")
 
@@ -33,7 +34,7 @@ case class ArangoConnectionURL(scheme: String, user: Option[String], password: O
     val userInfo = trimToNull(Seq(user, password.map(_ => "*****")).flatten.mkString(":"))
     val commaSeparatedHostsString = hosts.map { case (host, port) => s"$host:$port" }.mkString(",")
 
-    new StringBuilder()
+    new mutable.StringBuilder()
       .append(s"$scheme://")
       .having(userInfo.nonBlankOption)(_ append _ append "@")
       .append(commaSeparatedHostsString)
@@ -45,6 +46,8 @@ case class ArangoConnectionURL(scheme: String, user: Option[String], password: O
 }
 
 object ArangoConnectionURL {
+
+  import za.co.absa.commons.lang.extensions.StringExtension._
 
   private[persistence] val ArangoDbScheme = "arangodb"
   private[persistence] val ArangoSecureDbScheme = "arangodbs"

--- a/persistence/src/main/scala/za/co/absa/spline/persistence/ArangoDatabaseFacade.scala
+++ b/persistence/src/main/scala/za/co/absa/spline/persistence/ArangoDatabaseFacade.scala
@@ -21,7 +21,6 @@ import com.arangodb.async.{ArangoDBAsync, ArangoDatabaseAsync}
 import com.arangodb.velocypack.module.scala.VPackScalaModule
 import org.slf4s.Logging
 import org.springframework.beans.factory.DisposableBean
-import za.co.absa.commons.lang.OptionImplicits.AnyWrapper
 import za.co.absa.commons.version.Version
 import za.co.absa.commons.version.impl.SemVer20Impl.SemanticVersion
 
@@ -31,6 +30,7 @@ import scala.concurrent._
 class ArangoDatabaseFacade(connectionURL: ArangoConnectionURL, maybeSSLContext: Option[SSLContext], activeFailover: Boolean)
   extends DisposableBean {
 
+  import za.co.absa.commons.lang.extensions.AnyExtension._
   import za.co.absa.spline.persistence.ArangoDatabaseFacade._
 
   private val ArangoConnectionURL(_, maybeUser, maybePassword, hostsWithPorts, dbName) = connectionURL

--- a/producer-model-mapper/src/main/scala/za/co/absa/spline/producer/modelmapper/v1_0/spark/SparkSplineExpressionConverter.scala
+++ b/producer-model-mapper/src/main/scala/za/co/absa/spline/producer/modelmapper/v1_0/spark/SparkSplineExpressionConverter.scala
@@ -26,7 +26,7 @@ class SparkSplineExpressionConverter(
   attrRefConverter: AttributeRefConverter
 ) extends ExpressionConverter {
 
-  import za.co.absa.commons.lang.OptionImplicits._
+  import za.co.absa.commons.lang.extensions.TraversableExtension._
 
   override def isExpression(obj: Any): Boolean = PartialFunction.cond(obj) {
     case exprDef: TypesV10.ExprDef@unchecked => exprDef

--- a/producer-services/src/main/scala/za/co/absa/spline/producer/service/model/ExecutionPlanPersistentModelBuilder.scala
+++ b/producer-services/src/main/scala/za/co/absa/spline/producer/service/model/ExecutionPlanPersistentModelBuilder.scala
@@ -20,8 +20,8 @@ import scalax.collection.Graph
 import scalax.collection.GraphEdge.DiEdge
 import scalax.collection.GraphPredef._
 import za.co.absa.commons.graph.GraphImplicits._
-import za.co.absa.commons.lang.CollectionImplicits._
-import za.co.absa.commons.lang.OptionImplicits._
+import za.co.absa.commons.lang.extensions.AnyExtension._
+import za.co.absa.commons.lang.extensions.TraversableOnceExtension._
 import za.co.absa.spline.persistence.DefaultJsonSerDe._
 import za.co.absa.spline.persistence.model.{Edge, EdgeDef}
 import za.co.absa.spline.persistence.{model => pm}

--- a/producer-services/src/test/scala/za/co/absa/spline/producer/service/model/ExecutionPlanPersistentModelBuilderSpec.scala
+++ b/producer-services/src/test/scala/za/co/absa/spline/producer/service/model/ExecutionPlanPersistentModelBuilderSpec.scala
@@ -24,7 +24,7 @@ import za.co.absa.spline.producer.service.model.ExecutionPlanPersistentModelBuil
 
 class ExecutionPlanPersistentModelBuilderSpec extends AnyFlatSpec with Matchers {
 
-  import za.co.absa.commons.lang.OptionImplicits._
+  import za.co.absa.commons.lang.extensions.TraversableExtension._
 
   behavior of "ExecutionPlanPersistentModelBuilder"
   behavior of "getSchemaInfos"

--- a/producer-services/src/test/scala/za/co/absa/spline/producer/service/repo/ExecutionPlanDeserFixAspectSpec.scala
+++ b/producer-services/src/test/scala/za/co/absa/spline/producer/service/repo/ExecutionPlanDeserFixAspectSpec.scala
@@ -72,7 +72,7 @@ class ExecutionPlanDeserFixAspectSpec
 
 object ExecutionPlanDeserFixAspectSpec {
 
-  import za.co.absa.commons.lang.OptionImplicits._
+  import za.co.absa.commons.lang.extensions.TraversableExtension._
 
   class ProceedingJoinPointSpy(args: AnyRef*) extends ProceedingJoinPoint {
     var capturedProceedingArgs: Seq[AnyRef] = _


### PR DESCRIPTION
fixes #1122 

The problem was in the incorrect serialization of `bindVars` to VPack. Specifically the `lblValues:Array[Array[String]] -> Seq[...] -> Java -> VPack`. The fix was to eliminate unnecessary conversions, and only pass `Array[Array[String]]` types to VPack that do not require Scala to Java conversion and is properly supported.

1. Fixed the `bindVars` serialization
2. Updated commons to the latest 1.3.0
3. Fixed some deprecation warnings