### PR TITLE
spline #1158 Fix: Label filter still not working

### DIFF
--- a/arangodb-foxx-api/src/main/scala/za/co/absa/spline/persistence/model/entities.scala
+++ b/arangodb-foxx-api/src/main/scala/za/co/absa/spline/persistence/model/entities.scala
@@ -163,7 +163,8 @@ case class ExecPlanDetails(
   dataSourceUri: DataSource.Uri,
   dataSourceName: DataSource.Name,
   dataSourceType: String,
+  labels: Map[String, Seq[String]],
   append: Boolean
 ) {
-  def this() = this(null, null, null, null, null, null, false) // NOSONAR
+  def this() = this(null, null, null, null, null, null, null, false) // NOSONAR
 }

--- a/arangodb-foxx-services/src/main/services/execution-event-store.ts
+++ b/arangodb-foxx-services/src/main/services/execution-event-store.ts
@@ -55,6 +55,7 @@ export function storeExecutionEvent(progress: Progress): void {
             'dataSourceUri': dataSourceUri,
             'dataSourceName': dataSourceName,
             'dataSourceType': dataSourceType,
+            'labels': ep.labels,
             'append': append
         }
 

--- a/consumer-services/src/main/scala/za/co/absa/spline/consumer/service/repo/ExecutionEventRepositoryImpl.scala
+++ b/consumer-services/src/main/scala/za/co/absa/spline/consumer/service/repo/ExecutionEventRepositoryImpl.scala
@@ -118,7 +118,12 @@ class ExecutionEventRepositoryImpl @Autowired()(db: ArangoDatabaseAsync) extends
       ${
         lblNames.zipWithIndex.map({
           case (lblName, i) =>
-            s"    AND @lblValues[$i] ANY == ee.labels['${escapeJavaScript(lblName)}']"
+            s"""
+               | AND (
+               |      @lblValues[$i] ANY == ee.labels['${escapeJavaScript(lblName)}']
+               |   OR @lblValues[$i] ANY == ee.execPlanDetails.labels['${escapeJavaScript(lblName)}']
+               | )
+             """.stripMargin
         }).mkString("\n")
       }
          |        AND (@searchTerm == null

--- a/persistence/src/main/resources/migration-scripts/0.7.0-1.0.0.js
+++ b/persistence/src/main/resources/migration-scripts/0.7.0-1.0.0.js
@@ -43,11 +43,10 @@ console.log("[Spline] Add 'progress.labels and progress.planKey'");
 db._query(aql`
     WITH progress
     FOR ee IN progress
-        FILTER ee.labels == null
         UPDATE ee WITH {
             labels: {},
             planKey: PARSE_IDENTIFIER(FIRST(FOR po IN progressOf FILTER po._from == ee._id RETURN po._to)).key
-        } IN progress
+        } IN progress OPTIONS { mergeObjects: true }
 `);
 
 console.log("[Spline] Add 'executionPlan.labels'");
@@ -114,6 +113,13 @@ db._createView("progress_view", "arangosearch", {})
                     "_created": {},
                     "execPlanDetails": {
                         "fields": {
+                            "labels": {
+                                "analyzers": [
+                                    "norm_en",
+                                    "identity"
+                                ],
+                                "includeAllFields": true
+                            },
                             "dataSourceUri": {
                                 "analyzers": [
                                     "norm_en",
@@ -186,6 +192,13 @@ db._createView("dataSource_view", "arangosearch", {})
                             "durationNs": {},
                             "execPlanDetails": {
                                 "fields": {
+                                    "labels": {
+                                        "analyzers": [
+                                            "norm_en",
+                                            "identity"
+                                        ],
+                                        "includeAllFields": true
+                                    },
                                     "dataSourceType": {
                                         "analyzers": [
                                             "norm_en"

--- a/persistence/src/main/scala/za/co/absa/spline/persistence/model/persistentDefs.scala
+++ b/persistence/src/main/scala/za/co/absa/spline/persistence/model/persistentDefs.scala
@@ -248,6 +248,8 @@ object SearchViewDef {
             FieldLink.on("frameworkName").analyzers(NormSearchAnalyzer.name),
             FieldLink.on("dataSourceUri").analyzers(NormSearchAnalyzer.name, AnalyzerType.identity.name),
             FieldLink.on("dataSourceType").analyzers(NormSearchAnalyzer.name),
+            FieldLink.on("labels")
+              .includeAllFields(true).analyzers(NormSearchAnalyzer.name, AnalyzerType.identity.name),
           ),
           FieldLink.on("labels")
             .includeAllFields(true).analyzers(NormSearchAnalyzer.name, AnalyzerType.identity.name),
@@ -277,6 +279,8 @@ object SearchViewDef {
                 FieldLink.on("applicationName").analyzers(NormSearchAnalyzer.name),
                 FieldLink.on("frameworkName").analyzers(NormSearchAnalyzer.name),
                 FieldLink.on("dataSourceType").analyzers(NormSearchAnalyzer.name),
+                FieldLink.on("labels")
+                  .includeAllFields(true).analyzers(NormSearchAnalyzer.name, AnalyzerType.identity.name),
               )
             )
         )


### PR DESCRIPTION
fixes #1158

1. Add `labels` field to the `progress.execPlanDetails`
2. Add `progress.execPlanDetails.labels` in both existing search views
3. Add a corresponding search predicate to the execution events query
4. Fix migration `0.7.0-1.0.0` migration script accordingly