### PR TITLE
Fix for Dockerfile smell DL3025

### DIFF
--- a/test-data-generator/Dockerfile
+++ b/test-data-generator/Dockerfile
@@ -36,4 +36,4 @@ ADD ./target/${JAR_FILE} /opt/test-data-generator.jar
 ADD send-plans-and-events-docker.sh /opt/send-plans-and-events-docker.sh
 
 ENTRYPOINT ["sh", "/opt/send-plans-and-events-docker.sh"]
-CMD "--help"
+CMD [ "--help" ]

--- a/test-data-generator/Dockerfile
+++ b/test-data-generator/Dockerfile
@@ -36,4 +36,4 @@ ADD ./target/${JAR_FILE} /opt/test-data-generator.jar
 ADD send-plans-and-events-docker.sh /opt/send-plans-and-events-docker.sh
 
 ENTRYPOINT ["sh", "/opt/send-plans-and-events-docker.sh"]
-CMD [ "--help" ]
+CMD ["--help"]


### PR DESCRIPTION
Hi!
The Dockerfile placed at "test-data-generator/Dockerfile" contains the best practice violation [DL3025](https://github.com/hadolint/hadolint/wiki/DL3025) detected by the [hadolint](https://github.com/hadolint/hadolint) tool.

The smell DL3025 occurs if the JSON notation is not used for the arguments of CMD and ENTRYPOINT instructions.
This pull request proposes a fix for that smell generated by my fixing tool. The patch was manually verified before opening the pull request.
To fix this smell, specifically, the command arguments are refactored in the JSON notation format.

This change is only aimed at fixing that specific smell. If the fix is not valid or useful, please briefly indicate the reason and suggestions for possible improvements.

Thanks in advance