### PR TITLE
Minor fix in POM

### DIFF
--- a/build/parent-pom/pom.xml
+++ b/build/parent-pom/pom.xml
@@ -458,6 +458,11 @@
                 <version>${springfox-swagger.version}</version>
             </dependency>
             <dependency>
+                <groupId>io.springfox</groupId>
+                <artifactId>springfox-core</artifactId>
+                <version>${springfox-swagger.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>io.swagger</groupId>
                 <artifactId>swagger-annotations</artifactId>
                 <version>1.6.10</version>

--- a/producer-rest-core/pom.xml
+++ b/producer-rest-core/pom.xml
@@ -88,7 +88,6 @@
         <dependency>
             <groupId>io.springfox</groupId>
             <artifactId>springfox-core</artifactId>
-            <version>2.9.2</version>
         </dependency>
         <dependency>
             <groupId>com.twitter</groupId>


### PR DESCRIPTION
replace hardcoded version of `springfox-core` with the existing property `springfox-swagger.version`, and move it to the respective dependency management section