### PR TITLE
Feature/spline 1251 multi arch docker

### DIFF
--- a/admin/Dockerfile
+++ b/admin/Dockerfile
@@ -17,9 +17,7 @@
 # Run image using:
 # $> docker run --rm -it absaoss/spline-admin:latest
 
-ARG DOCKER_BASE_IMAGE_PREFIX
-
-FROM "$DOCKER_BASE_IMAGE_PREFIX"adoptopenjdk:11-jre
+FROM adoptopenjdk:11-jre
 
 ARG PROJECT_BUILD_FINAL_NAME
 

--- a/admin/Dockerfile
+++ b/admin/Dockerfile
@@ -21,10 +21,7 @@ ARG DOCKER_BASE_IMAGE_PREFIX
 
 FROM "$DOCKER_BASE_IMAGE_PREFIX"adoptopenjdk:11-jre
 
-ARG VERSION
-ARG IMAGE_NAME
-
-ENV IMAGE_NAME=$IMAGE_NAME
+ARG PROJECT_BUILD_FINAL_NAME
 
 LABEL \
     vendor="ABSA" \
@@ -40,7 +37,7 @@ RUN apt-get update \
 
 USER 1001
 
-COPY target/admin-$VERSION.jar ./admin.jar
+COPY target/$PROJECT_BUILD_FINAL_NAME.jar ./admin.jar
 COPY entrypoint.sh .
 
 ENTRYPOINT ["tini", "-g", "--", "sh", "./entrypoint.sh"]

--- a/admin/pom.xml
+++ b/admin/pom.xml
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2019 ABSA Group Limited                                       
-  ~                                                                         
-  ~ Licensed under the Apache License, Version 2.0 (the "License");         
-  ~ you may not use this file except in compliance with the License.        
-  ~ You may obtain a copy of the License at                                 
-  ~                                                                         
-  ~     http://www.apache.org/licenses/LICENSE-2.0                          
-  ~                                                                         
-  ~ Unless required by applicable law or agreed to in writing, software     
-  ~ distributed under the License is distributed on an "AS IS" BASIS,       
+  ~ Copyright 2019 ABSA Group Limited
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
   ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and     
-  ~ limitations under the License.                                          
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -77,7 +77,9 @@
         </resources>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
+                <version>3.3.0</version>
                 <configuration>
                     <descriptorRefs>
                         <descriptorRef>jar-with-dependencies</descriptorRef>
@@ -104,10 +106,6 @@
                 <artifactId>dockerfile-maven-plugin</artifactId>
                 <configuration>
                     <skip>false</skip>
-                    <buildArgs>
-                        <VERSION>${project.version}</VERSION>
-                        <IMAGE_NAME>${dockerfile.imageName}</IMAGE_NAME>
-                    </buildArgs>
                 </configuration>
             </plugin>
         </plugins>

--- a/admin/pom.xml
+++ b/admin/pom.xml
@@ -102,8 +102,8 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>com.spotify</groupId>
-                <artifactId>dockerfile-maven-plugin</artifactId>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
                 <configuration>
                     <skip>false</skip>
                 </configuration>

--- a/build/parent-pom/pom.xml
+++ b/build/parent-pom/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>za.co.absa</groupId>
         <artifactId>root-pom</artifactId>
-        <version>1.0.5</version>
+        <version>1.0.11</version>
     </parent>
 
     <groupId>za.co.absa.spline</groupId>

--- a/build/parent-pom/pom.xml
+++ b/build/parent-pom/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>za.co.absa</groupId>
         <artifactId>root-pom</artifactId>
-        <version>1.0.0</version>
+        <version>1.0.5</version>
     </parent>
 
     <groupId>za.co.absa.spline</groupId>

--- a/build/parent-pom/pom.xml
+++ b/build/parent-pom/pom.xml
@@ -19,11 +19,12 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>za.co.absa.spline</groupId>
-        <artifactId>package-pom</artifactId>
-        <version>0.6.1</version>
+        <groupId>za.co.absa</groupId>
+        <artifactId>root-pom</artifactId>
+        <version>1.0.0</version>
     </parent>
 
+    <groupId>za.co.absa.spline</groupId>
     <artifactId>parent-pom</artifactId>
     <packaging>pom</packaging>
 
@@ -54,6 +55,7 @@
             <plugin>
                 <groupId>net.alchim31.maven</groupId>
                 <artifactId>scala-maven-plugin</artifactId>
+                <version>4.5.0</version>
                 <configuration>
                     <scalaVersion>${scala.version}</scalaVersion>
                     <args>
@@ -94,6 +96,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.2</version>
                 <configuration>
                     <skipTests>true</skipTests>
                 </configuration>
@@ -102,6 +105,7 @@
             <plugin>
                 <groupId>com.github.cerveada</groupId>
                 <artifactId>scalatest-maven-plugin</artifactId>
+                <version>2.0.1</version>
                 <configuration>
                     <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
                     <junitxml>.</junitxml>

--- a/kafka-gateway/Dockerfile
+++ b/kafka-gateway/Dockerfile
@@ -14,9 +14,7 @@
 # limitations under the License.
 #
 
-ARG DOCKER_BASE_IMAGE_PREFIX=
-
-FROM "$DOCKER_BASE_IMAGE_PREFIX"tomcat:9-jre11-openjdk-slim-buster
+FROM tomcat:9-jre11-openjdk-slim-buster
 
 LABEL \
     vendor="ABSA" \

--- a/kafka-gateway/Dockerfile
+++ b/kafka-gateway/Dockerfile
@@ -16,7 +16,7 @@
 
 ARG DOCKER_BASE_IMAGE_PREFIX=
 
-FROM "$DOCKER_BASE_IMAGE_PREFIX"tomcat:9.0.45-jdk11-corretto
+FROM "$DOCKER_BASE_IMAGE_PREFIX"tomcat:9-jre11-openjdk-slim-buster
 
 LABEL \
     vendor="ABSA" \

--- a/kafka-gateway/pom.xml
+++ b/kafka-gateway/pom.xml
@@ -75,6 +75,19 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-war-plugin</artifactId>
+                <version>3.2.3</version>
+                <configuration>
+                    <failOnMissingWebXml>false</failOnMissingWebXml>
+                    <archive>
+                        <manifestEntries>
+                            <Build-Time>${maven.build.timestamp}</Build-Time>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>com.spotify</groupId>
                 <artifactId>dockerfile-maven-plugin</artifactId>
                 <configuration>

--- a/kafka-gateway/pom.xml
+++ b/kafka-gateway/pom.xml
@@ -88,8 +88,8 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>com.spotify</groupId>
-                <artifactId>dockerfile-maven-plugin</artifactId>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
                 <configuration>
                     <skip>false</skip>
                     <buildArgs>

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
+    <groupId>za.co.absa.spline</groupId>
     <artifactId>spline</artifactId>
     <version>0.7.8-SNAPSHOT</version>
 
@@ -31,10 +32,32 @@
     </scm>
 
     <parent>
-        <groupId>za.co.absa.spline</groupId>
-        <artifactId>package-pom</artifactId>
-        <version>0.6.1</version>
+        <groupId>za.co.absa</groupId>
+        <artifactId>root-pom</artifactId>
+        <version>1.0.0</version>
     </parent>
+
+    <developers>
+        <developer>
+            <id>wajda</id>
+            <name>Oleksandr Vayda</name>
+            <roles>
+                <role>Tech Lead</role>
+                <role>Full-stack developer</role>
+            </roles>
+            <timezone>Europe/Prague</timezone>
+            <url>https://github.com/wajda</url>
+        </developer>
+        <developer>
+            <id>cerveada</id>
+            <name>Adam Červenka</name>
+            <roles>
+                <role>Back-end developer</role>
+            </roles>
+            <timezone>Europe/Prague</timezone>
+            <url>https://github.com/cerveada</url>
+        </developer>
+    </developers>
 
     <modules>
         <module>build/parent-pom</module>

--- a/rest-gateway/Dockerfile
+++ b/rest-gateway/Dockerfile
@@ -14,9 +14,7 @@
 # limitations under the License.
 #
 
-ARG DOCKER_BASE_IMAGE_PREFIX=
-
-FROM "$DOCKER_BASE_IMAGE_PREFIX"tomcat:9-jre11-openjdk-slim-buster
+FROM tomcat:9-jre11-openjdk-slim-buster
 
 LABEL \
     vendor="ABSA" \

--- a/rest-gateway/Dockerfile
+++ b/rest-gateway/Dockerfile
@@ -16,7 +16,7 @@
 
 ARG DOCKER_BASE_IMAGE_PREFIX=
 
-FROM "$DOCKER_BASE_IMAGE_PREFIX"tomcat:9.0.45-jdk11-corretto
+FROM "$DOCKER_BASE_IMAGE_PREFIX"tomcat:9-jre11-openjdk-slim-buster
 
 LABEL \
     vendor="ABSA" \

--- a/rest-gateway/pom.xml
+++ b/rest-gateway/pom.xml
@@ -165,8 +165,8 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>com.spotify</groupId>
-                <artifactId>dockerfile-maven-plugin</artifactId>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
                 <configuration>
                     <skip>false</skip>
                     <buildArgs>

--- a/rest-gateway/pom.xml
+++ b/rest-gateway/pom.xml
@@ -68,6 +68,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
+                <version>1.5.0</version>
                 <executions>
                     <execution>
                         <id>gen-swagger-consumer-json</id>
@@ -121,7 +122,9 @@
                 </dependencies>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-antrun-plugin</artifactId>
+                <version>1.8</version>
                 <executions>
                     <execution>
                         <phase>prepare-package</phase>
@@ -144,7 +147,9 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
+                <version>3.2.3</version>
                 <configuration>
                     <failOnMissingWebXml>false</failOnMissingWebXml>
                     <archive>


### PR DESCRIPTION
fixes #1251

- Update root pom version to 1.0.11 that supports multi-arch docker builds
- Backported from _develop_ several docker related PRs: #900, #889, #1166