### PR TITLE
Bugfix/spline 1266 tx info discrepancy and index

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,8 +10,12 @@ max_line_length = 140
 
 [*.scala]
 indent_size = 2
+ij_scala_indent_first_parameter = false
+ij_scala_indent_first_parameter_clause = true
+ij_scala_method_parameters_new_line_after_left_paren = true
+ij_scala_method_parameters_right_paren_on_new_line = true
 
-[{*.ts, *.js}]
+[{*.ts,*.js}]
 indent_size = 4
 
 # quotes

--- a/admin/src/main/scala/za/co/absa/spline/admin/AdminCLI.scala
+++ b/admin/src/main/scala/za/co/absa/spline/admin/AdminCLI.scala
@@ -289,7 +289,7 @@ class AdminCLI(dbManagerFactory: ArangoManagerFactory, maybeConsole: Option[Inpu
           case _ => Fail
         }
         val dbManager = interactiveDbManagerFactory.create(url, sslCtxOpt, conf.dryRun)
-        val wasInitialized = Await.result(dbManager.initialize(onExistsAction, options), Duration.Inf)
+        val wasInitialized = Await.result(dbManager.createDatabase(onExistsAction, options), Duration.Inf)
         if (!wasInitialized) println(ansi"%yellow{Skipped. DB is already initialized}")
 
       case DBUpgrade(url) =>

--- a/admin/src/main/scala/za/co/absa/spline/arango/ArangoManager.scala
+++ b/admin/src/main/scala/za/co/absa/spline/arango/ArangoManager.scala
@@ -41,7 +41,7 @@ trait ArangoManager {
   /**
    * @return `true` if actual initialization was performed.
    */
-  def initialize(onExistsAction: OnDBExistsAction, options: DatabaseCreateOptions): Future[Boolean]
+  def createDatabase(onExistsAction: OnDBExistsAction, options: DatabaseCreateOptions): Future[Boolean]
   def upgrade(): Future[Unit]
   def execute(actions: AuxiliaryDBAction*): Future[Unit]
   def prune(retentionPeriod: Duration): Future[Unit]
@@ -65,7 +65,7 @@ class ArangoManagerImpl(
 
   import ArangoManagerImpl._
 
-  def initialize(onExistsAction: OnDBExistsAction, options: DatabaseCreateOptions): Future[Boolean] = {
+  def createDatabase(onExistsAction: OnDBExistsAction, options: DatabaseCreateOptions): Future[Boolean] = {
     log.debug("Initialize database")
     db.exists.toScala.flatMap { exists =>
       if (exists && onExistsAction == Skip) {

--- a/admin/src/main/scala/za/co/absa/spline/arango/ArangoManager.scala
+++ b/admin/src/main/scala/za/co/absa/spline/arango/ArangoManager.scala
@@ -211,7 +211,7 @@ class ArangoManagerImpl(
     Future.sequence(
       for {
         colDef <- sealedInstancesOf[CollectionDef]
-        idxDef <- colDef.indexDefs
+        idxDef <- colDef.indexDefs ++ colDef.commonIndexDefs
       } yield {
         val idxOpts = idxDef.options
         log.debug(s"Ensure ${idxOpts.indexType} index: ${colDef.name} [${idxDef.fields.mkString(",")}]")

--- a/admin/src/test/scala/za/co/absa/spline/admin/AdminCLISpec.scala
+++ b/admin/src/test/scala/za/co/absa/spline/admin/AdminCLISpec.scala
@@ -83,7 +83,7 @@ class AdminCLISpec
       thenReturn arangoManagerMock)
 
     (when(
-      arangoManagerMock.initialize(actionFlgCaptor.capture, dbOptionCaptor.capture))
+      arangoManagerMock.createDatabase(actionFlgCaptor.capture, dbOptionCaptor.capture))
       thenReturn Future.successful(true))
 
     (when(

--- a/admin/src/test/scala/za/co/absa/spline/package.scala
+++ b/admin/src/test/scala/za/co/absa/spline/package.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2023 ABSA Group Limited
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa
+
+import org.scalatestplus.mockito.MockitoSugar.mock
+
+import scala.reflect.ClassTag
+
+package object spline {
+  /**
+   * This is just to add another word for `Mockito.mock` method, for better test readability.
+   *
+   * @tparam A type of the dummy
+   * @return a dummy instance of the given type
+   */
+  def dummy[A <: AnyRef : ClassTag]: A = mock[A]
+}

--- a/arangodb-foxx-services/src/main/persistence/model.ts
+++ b/arangodb-foxx-services/src/main/persistence/model.ts
@@ -124,5 +124,5 @@ export type TxParams = Partial<{
 }>
 
 export type TxAwareDocument = {
-    _tx_info?: WriteTxInfo
+    _txInfo?: WriteTxInfo
 }

--- a/arangodb-foxx-services/src/main/services/txm/tx-manager-impl.ts
+++ b/arangodb-foxx-services/src/main/services/txm/tx-manager-impl.ts
@@ -126,7 +126,7 @@ export class TxManagerImpl implements TxManager {
         // Not using Array.every() for performance reasons,
         // for-loop is several time faster.
         for (let i = 0; i < n; i++) {
-            const wtx: WriteTxInfo | undefined = docs[i]?._tx_info
+            const wtx: WriteTxInfo | undefined = docs[i]?._txInfo
             if (wtx === undefined)
                 continue
             if (wtx.num >= rtxNum || liveTxIds.includes(wtx.uid))

--- a/arangodb-foxx-services/src/main/utils/aql-gen-helper.ts
+++ b/arangodb-foxx-services/src/main/utils/aql-gen-helper.ts
@@ -44,8 +44,8 @@ export class AQLCodeGenHelper {
         const pruneOrLet = aql.literal(isTraversal ? 'PRUNE' : 'LET')
         return aql`
             ${pruneOrLet} ${pruneVar} = LENGTH([${args}][*
-                FILTER CURRENT._tx_info.num >= ${this.rtxInfo}.num
-                    OR POSITION(${this.rtxInfo}.liveTxIds, CURRENT._tx_info.uid)
+                FILTER CURRENT._txInfo.num >= ${this.rtxInfo}.num
+                    OR POSITION(${this.rtxInfo}.liveTxIds, CURRENT._txInfo.uid)
                 LIMIT 1
                 RETURN CURRENT._id
             ]) != 0

--- a/arangodb-foxx-services/tests/main/utils/aql-gen-helper.spec.ts
+++ b/arangodb-foxx-services/tests/main/utils/aql-gen-helper.spec.ts
@@ -29,8 +29,8 @@ test('genTxIsolationCodeForTraversal', () => {
     expect(query.bindVars).toEqual({ 'value0': dummyRtxInfo })
     expect(dedent(query.query)).toEqual(dedent(`
         PRUNE __isAnyUncommitted_1 = LENGTH([foo, bar][*
-            FILTER CURRENT._tx_info.num >= @value0.num
-                OR POSITION(@value0.liveTxIds, CURRENT._tx_info.uid)
+            FILTER CURRENT._txInfo.num >= @value0.num
+                OR POSITION(@value0.liveTxIds, CURRENT._txInfo.uid)
             LIMIT 1
             RETURN CURRENT._id
         ]) != 0
@@ -44,8 +44,8 @@ test('genTxIsolationCodeForLoop', () => {
     expect(query.bindVars).toEqual({ 'value0': dummyRtxInfo })
     expect(dedent(query.query)).toEqual(dedent(`
         LET __isAnyUncommitted_1 = LENGTH([foo, bar][*
-            FILTER CURRENT._tx_info.num >= @value0.num
-                OR POSITION(@value0.liveTxIds, CURRENT._tx_info.uid)
+            FILTER CURRENT._txInfo.num >= @value0.num
+                OR POSITION(@value0.liveTxIds, CURRENT._txInfo.uid)
             LIMIT 1
             RETURN CURRENT._id
         ]) != 0

--- a/persistence/src/main/scala/za/co/absa/spline/persistence/ArangoDatabaseFacade.scala
+++ b/persistence/src/main/scala/za/co/absa/spline/persistence/ArangoDatabaseFacade.scala
@@ -16,13 +16,11 @@
 
 package za.co.absa.spline.persistence
 
-import com.arangodb.DbName
 import com.arangodb.async.{ArangoDBAsync, ArangoDatabaseAsync}
 import com.arangodb.velocypack.module.scala.VPackScalaModule
 import org.slf4s.Logging
 import org.springframework.beans.factory.DisposableBean
 import za.co.absa.commons.version.Version
-import za.co.absa.commons.version.impl.SemVer20Impl.SemanticVersion
 
 import javax.net.ssl._
 import scala.concurrent._
@@ -62,7 +60,7 @@ class ArangoDatabaseFacade(connectionURL: ArangoConnectionURL, maybeSSLContext: 
   // The val is lazy to not prevent a facade instance from being created.
   // It allows connection to be re-attempted later and the {{shutdown()}} method to be called.
   lazy val db: ArangoDatabaseAsync = {
-    val db = arango.db(DbName.of(dbName))
+    val db = arango.db(dbName)
     warmUpDb(db)
     db
   }

--- a/persistence/src/main/scala/za/co/absa/spline/persistence/model/persistentDefs.scala
+++ b/persistence/src/main/scala/za/co/absa/spline/persistence/model/persistentDefs.scala
@@ -27,12 +27,20 @@ import za.co.absa.spline.persistence.model.SearchAnalyzerDef.NormSearchAnalyzer
 
 case class IndexDef(fields: Seq[String], options: IndexOptions[_ <: IndexOptions[_]])
 
-sealed trait GraphElementDef
+sealed trait IndexableDef {
+  def indexDefs: Seq[IndexDef] = Nil
+  def commonIndexDefs: Seq[IndexDef] = Nil
+}
 
-sealed trait CollectionDef {
+sealed trait GraphElementDef extends IndexableDef {
+  override def commonIndexDefs: Seq[IndexDef] = Seq(
+    IndexDef(Seq("_txInfo.uid"), new PersistentIndexOptions().estimates(false)),
+  )
+}
+
+sealed trait CollectionDef extends IndexableDef {
   def name: String
   def collectionType: CollectionType
-  def indexDefs: Seq[IndexDef] = Nil
   def numShards: Int = 1
   def shardKeys: Seq[String] = Seq("_key")
   def replFactor: Int = 1

--- a/persistence/src/test/scala/com/arangodb/model/ImplicitsSpec.scala
+++ b/persistence/src/test/scala/com/arangodb/model/ImplicitsSpec.scala
@@ -20,8 +20,6 @@ import com.arangodb.entity.IndexType
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-import scala.annotation.nowarn
-
 class ImplicitsSpec extends AnyFlatSpec with Matchers {
 
   import com.arangodb.model.Implicits._
@@ -29,11 +27,10 @@ class ImplicitsSpec extends AnyFlatSpec with Matchers {
   behavior of "IndexOptionsOps.indexType"
 
   it should "resolve index type" in {
-    (new SkiplistIndexOptions@nowarn).indexType should be theSameInstanceAs IndexType.skiplist
     (new GeoIndexOptions).indexType should be theSameInstanceAs IndexType.geo
-    (new TtlIndexOptions).indexType should be theSameInstanceAs IndexType.ttl
-    (new FulltextIndexOptions).indexType should be theSameInstanceAs IndexType.fulltext
-    (new HashIndexOptions@nowarn).indexType should be theSameInstanceAs IndexType.hash
+    (new InvertedIndexOptions).indexType should be theSameInstanceAs IndexType.inverted
     (new PersistentIndexOptions).indexType should be theSameInstanceAs IndexType.persistent
+    (new TtlIndexOptions).indexType should be theSameInstanceAs IndexType.ttl
+    (new ZKDIndexOptions).indexType should be theSameInstanceAs IndexType.zkd
   }
 }


### PR DESCRIPTION
Fixes #1266

1. Rename `_tx_info` into `_txInfo` as it should be
2. Improve document removal query performance on TX rollback by only filtering on `_txInfo.uid` instead of the entire `_txInfo` object.
3. Add persistent index on `_txInfo.uid` to all graph nodes and edges
4. Fix some minor deprecations