### PR TITLE
issue #1341 Consumer API should respond with 400 on missing required params

### DIFF
--- a/consumer-rest-core/src/main/scala/za/co/absa/spline/consumer/rest/controller/ErrorControllerAdvice.scala
+++ b/consumer-rest-core/src/main/scala/za/co/absa/spline/consumer/rest/controller/ErrorControllerAdvice.scala
@@ -20,6 +20,7 @@ import org.springframework.beans.TypeMismatchException
 import org.springframework.http.HttpStatus._
 import org.springframework.http.ResponseEntity
 import org.springframework.http.converter.HttpMessageConversionException
+import org.springframework.web.bind.ServletRequestBindingException
 import org.springframework.web.bind.annotation.{ControllerAdvice, ExceptionHandler}
 import org.springframework.web.context.request.async.AsyncRequestTimeoutException
 import za.co.absa.commons.error.ErrorRef
@@ -34,7 +35,8 @@ class ErrorControllerAdvice {
 
   @ExceptionHandler(Array(
     classOf[TypeMismatchException],
-    classOf[HttpMessageConversionException]
+    classOf[HttpMessageConversionException],
+    classOf[ServletRequestBindingException],
   ))
   def badRequest(e: Exception): ResponseEntity[_] = new ResponseEntity(e.getMessage, BAD_REQUEST)
 

--- a/consumer-rest-core/src/main/scala/za/co/absa/spline/consumer/rest/controller/ImpactOverviewController.scala
+++ b/consumer-rest-core/src/main/scala/za/co/absa/spline/consumer/rest/controller/ImpactOverviewController.scala
@@ -41,7 +41,7 @@ class ImpactOverviewController @Autowired()(val repo: ImpactRepository) {
       """
   )
   def lineageOverview(
-    @ApiParam("Execution event ID")
+    @ApiParam(value = "Execution event ID", required = true)
     @RequestParam("eventId")
     eventId: String,
 

--- a/consumer-rest-core/src/main/scala/za/co/absa/spline/consumer/rest/controller/LineageDetailedController.scala
+++ b/consumer-rest-core/src/main/scala/za/co/absa/spline/consumer/rest/controller/LineageDetailedController.scala
@@ -42,7 +42,7 @@ class LineageDetailedController @Autowired()(val epRepo: ExecutionPlanRepository
     value = "Get detailed execution plan (DAG)",
     notes = "Returns a logical plan DAG by execution plan ID")
   def lineageDetailed(
-    @ApiParam(value = "Execution plan ID")
+    @ApiParam(value = "Execution plan ID", required = true)
     @RequestParam("execId") execId: ExecutionPlanInfo.Id
   ): Future[LineageDetailed] = {
     epRepo.findById(execId)
@@ -52,7 +52,7 @@ class LineageDetailedController @Autowired()(val epRepo: ExecutionPlanRepository
   @ApiOperation(
     value = "Get graph of attributes that depends on attribute with provided id")
   def attributeLineageAndImpact(
-     @ApiParam(value = "Attribute ID")
+     @ApiParam(value = "Attribute ID", required = true)
      @RequestParam("attributeId") attributeId: String
   ): Future[AttributeLineageAndImpact] =
     Future.sequence(Seq(

--- a/consumer-rest-core/src/main/scala/za/co/absa/spline/consumer/rest/controller/LineageOverviewController.scala
+++ b/consumer-rest-core/src/main/scala/za/co/absa/spline/consumer/rest/controller/LineageOverviewController.scala
@@ -42,7 +42,7 @@ class LineageOverviewController @Autowired()(val repo: LineageRepository) {
       """
   )
   def lineageOverview(
-    @ApiParam("Execution event ID")
+    @ApiParam(value = "Execution event ID", required = true)
     @RequestParam("eventId")
     eventId: String,
 


### PR DESCRIPTION
fixes #1341

- Map `ServletRequestBindingException` to HTTP 400
- Add `required` flag on the required REST GET params