### PR TITLE
issue #1300 TxManagerImpl.nextTxNumber(): Repeat attempt on racing condition

### DIFF
--- a/arangodb-foxx-services/README.md
+++ b/arangodb-foxx-services/README.md
@@ -13,19 +13,19 @@ mvn clean install
 ```shell
 # Deploy the "/spline" service to the "foo" database on the given ArangoDB server
 # (http://some.server:1234/_db/foo/spline/)
-npm foxx:deploy --database=foo --server=http://some.server:1234
+npm run foxx:deploy --database=foo --server=http://some.server:1234
 
 # If the "--server" option is omitted, the local server is used
 # (http://localhost:8529/_db/foo/spline/)
-npm foxx:deploy --database=foo
+npm run foxx:deploy --database=foo
 
 # Use "foxx:deploy-dev" to deploy the service in development mode (https://www.arangodb.com/docs/stable/foxx-guides-development-mode.html)
-npm foxx:deploy-dev --database=foo
+npm run foxx:deploy-dev --database=foo
 
 # If needed, in addition to the "foxx:deploy" script that executes build, uninstall and install steps,
 # you can also use individual "foxx:install" or "foxx:uninstall" scripts with the same arguments.
-npm foxx:uninstall --database=NAME [--server=URL]
-npm foxx:install --database=NAME [--server=URL]
+npm run foxx:uninstall --database=NAME [--server=URL]
+npm run foxx:install --database=NAME [--server=URL]
 ```
 
 ---


### PR DESCRIPTION
fixes #1300

The method `TxManagerImpl.nextTxNumber()` is supposed to be acting in an _increment-and-get_ fashion tolerating racing conditions. For that reason it should contain a loop to repeat attempts in case of a conflict.