### PR TITLE
issue #1352 Fix windows build

### DIFF
--- a/arangodb-foxx-services/.eslintrc.js
+++ b/arangodb-foxx-services/.eslintrc.js
@@ -37,8 +37,7 @@ module.exports = {
             4
         ],
         'linebreak-style': [
-            'error',
-            // eslint-disable-next-line no-undef
+            process.platform === 'win32' ? 'warn' : 'error',
             process.platform === 'win32' ? 'windows' : 'unix'
         ],
         quotes: [

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -59,4 +59,24 @@
         </dependency>
     </dependencies>
 
+    <profiles>
+        <profile>
+            <id>skip-it-tests</id>
+            <activation>
+                <!--
+                Integration-tests module depends on Testcontainers,
+                that are currently not supported on Windows.
+                See: https://github.com/testcontainers/testcontainers-java/issues/2960
+                Therefore we skip integration tests on Windows.
+                -->
+                <os>
+                    <family>windows</family>
+                </os>
+            </activation>
+            <properties>
+                <skipTests>true</skipTests>
+            </properties>
+        </profile>
+    </profiles>
+
 </project>


### PR DESCRIPTION
fixes #1352 

- Update the eslint rules to permit LF line endings on Windows
- Disable integration tests on Windows because of Testcontainers issue - https://github.com/testcontainers/testcontainers-java/issues/2960