### PR TITLE
spline #1419 Upgrade to Apache Configuration 2 due to CVE-2025-46392

### DIFF
--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,3 +1,3 @@
 # Enable auto-env through the sdkman_auto_env config
 # Add key=value pairs of SDKs to use below
-java=11.0.26-amzn
+java=11.0.27-amzn

--- a/admin/src/main/scala/za/co/absa/spline/admin/AppConfig.scala
+++ b/admin/src/main/scala/za/co/absa/spline/admin/AppConfig.scala
@@ -16,16 +16,20 @@
 
 package za.co.absa.spline.admin
 
-import org.apache.commons.configuration.{CompositeConfiguration, PropertiesConfiguration, SystemConfiguration}
+import org.apache.commons.configuration2.ConfigurationImplicits._
+import org.apache.commons.configuration2.builder.FileBasedConfigurationBuilder
+import org.apache.commons.configuration2.builder.fluent.Parameters
+import org.apache.commons.configuration2.{CompositeConfiguration, PropertiesConfiguration, SystemConfiguration}
 import za.co.absa.commons.config.ConfTyped
-import za.co.absa.commons.config.ConfigurationImplicits._
 
 import java.util
 
 object AppConfig
   extends CompositeConfiguration(util.Arrays.asList(
     new SystemConfiguration,
-    new PropertiesConfiguration(ClassLoader.getSystemResource("spline-cli.properties"))
+    new FileBasedConfigurationBuilder(classOf[PropertiesConfiguration])
+      .configure(new Parameters().fileBased().setURL(ClassLoader.getSystemResource("spline-cli.properties")))
+      .getConfiguration,
   )) with ConfTyped {
 
   private val conf = this

--- a/build/parent-pom/pom.xml
+++ b/build/parent-pom/pom.xml
@@ -404,9 +404,14 @@
                 <version>3.14.0</version>
             </dependency>
             <dependency>
-                <groupId>commons-configuration</groupId>
-                <artifactId>commons-configuration</artifactId>
-                <version>1.10</version>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-configuration2</artifactId>
+                <version>2.12.0</version>
+            </dependency>
+            <dependency>
+                <groupId>commons-beanutils</groupId>
+                <artifactId>commons-beanutils</artifactId>
+                <version>1.9.4</version>
             </dependency>
             <dependency>
                 <groupId>commons-io</groupId>

--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -39,8 +39,12 @@
             <artifactId>commons_${scala.compat.version}</artifactId>
         </dependency>
         <dependency>
-            <groupId>commons-configuration</groupId>
-            <artifactId>commons-configuration</artifactId>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-configuration2</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>commons-beanutils</groupId>
+            <artifactId>commons-beanutils</artifactId>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>

--- a/commons/src/main/scala/org/apache/commons/configuration2/ConfigurationImplicits.scala
+++ b/commons/src/main/scala/org/apache/commons/configuration2/ConfigurationImplicits.scala
@@ -1,0 +1,271 @@
+/*
+ * Copyright 2025 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.configuration2
+
+import org.apache.commons.lang3.StringUtils.{isBlank, isNotBlank}
+
+import scala.jdk.CollectionConverters._
+import scala.reflect.runtime.universe.{TypeTag, typeOf}
+import scala.util.Try
+
+
+/**
+ * The object contains extension methods for the [[org.apache.commons.configuration2.Configuration Configuration]] interface.
+ */
+//noinspection ScalaUnusedSymbol
+object ConfigurationImplicits {
+
+  /**
+   * The class wraps the [[org.apache.commons.configuration2.Configuration Configuration]] interface in order to provide extension methods.
+   *
+   * @param conf A configuration instance
+   * @tparam T A specific type implementing the [[org.apache.commons.configuration2.Configuration Configuration]] interface
+   */
+  implicit class ConfigurationRequiredWrapper[T <: Configuration](val conf: T) extends AnyVal {
+
+    /**
+     * Gets a value of an object configuration property and checks whether property exists.
+     *
+     * @return A value of an object configuration property if exists, otherwise throws an exception.
+     */
+    def getRequiredObject[A <: AnyRef]: String => A = getRequired[AnyRef](conf.getProperty, null.!=)(_).asInstanceOf[A]
+
+    /**
+     * Gets a value of string configuration property and checks whether property exists.
+     *
+     * @return A value of string configuration property if exists, otherwise throws an exception.
+     */
+    def getRequiredString: String => String = getRequired(conf.getString, isNotBlank)
+
+    /**
+     * Gets a value of string array configuration property and checks whether the array is not empty.
+     *
+     * @return A value of string array configuration property if not empty, otherwise throws an exception.
+     */
+    def getRequiredStringArray: String => Array[String] = getRequired(conf.getStringArray, (arr: Array[String]) => !arr.forall(isBlank))
+
+    /**
+     * Gets a value of boolean configuration property and checks whether property exists.
+     *
+     * @return A value of boolean configuration property if exists, otherwise throws an exception.
+     */
+    def getRequiredBoolean: String => Boolean = getRequired(conf.getBoolean(_, null), null.!=) //NOSONAR
+
+    /**
+     * Gets a value of big decimal configuration property and checks whether property exists.
+     *
+     * @return A value of big decimal configuration property if exists, otherwise throws an exception.
+     */
+    def getRequiredBigDecimal: String => BigDecimal = getRequired(conf.getBigDecimal(_, null), null.!=) //NOSONAR
+
+    /**
+     * Gets a value of byte configuration property and checks whether property exists.
+     *
+     * @return A value of byte configuration property if exists, otherwise throws an exception.
+     */
+    def getRequiredByte: String => Byte = getRequired(conf.getByte(_, null), null.!=) //NOSONAR
+
+    /**
+     * Gets a value of short configuration property and checks whether property exists.
+     *
+     * @return A value of short configuration property if exists, otherwise throws an exception.
+     */
+    def getRequiredShort: String => Short = getRequired(conf.getShort(_, null), null.!=) //NOSONAR
+
+    /**
+     * Gets a value of int configuration property and checks whether property exists.
+     *
+     * @return A value of int configuration property if exists, otherwise throws an exception.
+     */
+    def getRequiredInt: String => Int = getRequired(conf.getInteger(_, null), null.!=) //NOSONAR
+
+    /**
+     * Gets a value of long configuration property and checks whether property exists.
+     *
+     * @return A value of long configuration property if exists, otherwise throws an exception.
+     */
+    def getRequiredLong: String => Long = getRequired(conf.getLong(_, null), null.!=) //NOSONAR
+
+    /**
+     * Gets a value of float configuration property and checks whether property exists.
+     *
+     * @return A value of float configuration property if exists, otherwise throws an exception.
+     */
+    def getRequiredFloat: String => Float = getRequired(conf.getFloat(_, null), null.!=) //NOSONAR
+
+    /**
+     * Gets a value of double configuration property and checks whether property exists.
+     *
+     * @return A value of double configuration property if exists, otherwise throws an exception.
+     */
+    def getRequiredDouble: String => Double = getRequired(conf.getDouble(_, null), null.!=) //NOSONAR
+
+    private def getRequired[V](get: String => V, check: V => Boolean)(key: String): V = {
+      Try(get(key))
+        .filter(check)
+        .recover {
+          case _: NoSuchElementException =>
+            // rewrite exception message for clarity
+            throw new NoSuchElementException(s"Missing configuration property ${getFullPropName(key)}")
+          case e: Exception =>
+            throw new RuntimeException(s"Error in retrieving configuration property ${getFullPropName(key)}", e)
+        }
+        .get
+    }
+
+    private def getFullPropName(key: String) = conf match {
+      case sc: SubsetConfiguration => sc.getParentKey(key)
+      case _ => key
+    }
+  }
+
+  /**
+   * The class wraps the [[org.apache.commons.configuration2.Configuration Configuration]] interface in order to provide extension methods.
+   *
+   * @param conf A configuration instance
+   * @tparam T A specific type implementing the [[org.apache.commons.configuration2.Configuration Configuration]] interface
+   */
+  implicit class ConfigurationOptionalWrapper[T <: Configuration](val conf: T) extends AnyVal {
+
+    /**
+     * Gets a value of an object configuration property.
+     *
+     * @return A Some wrapped value of object configuration property if exists, otherwise None.
+     */
+    def getOptionalObject[A <: AnyRef]: String => Option[A] = getOptional[AnyRef](conf.getProperty)(_).map(_.asInstanceOf[A])
+
+    /**
+     * Gets a value of string configuration property.
+     *
+     * @return A Some wrapped value of string configuration property if exists, otherwise None.
+     */
+    def getOptionalString: String => Option[String] = getOptional(conf.getString)(_).filter(isNotBlank)
+
+
+    /**
+     * Gets a value of string array configuration property and checks whether the array is not empty.
+     *
+     * @return A Some wrapped value of string array configuration property if not empty, otherwise None.
+     */
+    def getOptionalStringArray: String => Option[Array[String]] = getOptional(conf.getStringArray)(_).filter(_.nonEmpty)
+
+    /**
+     * Gets a value of boolean configuration property.
+     *
+     * @return A Some wrapped value of boolean configuration property if exists, otherwise None.
+     */
+    def getOptionalBoolean: String => Option[Boolean] = getOptional(conf.getBoolean)
+
+    /**
+     * Gets a value of big decimal configuration property.
+     *
+     * @return A Some wrapped value of big decimal configuration property if exists, otherwise None.
+     */
+    //noinspection ConvertibleToMethodValue
+    def getOptionalBigDecimal: String => Option[BigDecimal] = getOptional(conf.getBigDecimal(_))
+
+    /**
+     * Gets a value of byte configuration property.
+     *
+     * @return A Some wrapped value of byte configuration property if exists, otherwise None.
+     */
+    def getOptionalByte: String => Option[Byte] = getOptional(conf.getByte)
+
+    /**
+     * Gets a value of short configuration property.
+     *
+     * @return A Some wrapped value of short configuration property if exists, otherwise None.
+     */
+    def getOptionalShort: String => Option[Short] = getOptional(conf.getShort)
+
+    /**
+     * Gets a value of int configuration property.
+     *
+     * @return A Some wrapped value of int configuration property if exists, otherwise None.
+     */
+    def getOptionalInt: String => Option[Int] = getOptional(conf.getInt)
+
+    /**
+     * Gets a value of long configuration property.
+     *
+     * @return A Some wrapped value of long configuration property if exists, otherwise None.
+     */
+    def getOptionalLong: String => Option[Long] = getOptional(conf.getLong)
+
+    /**
+     * Gets a value of float configuration property.
+     *
+     * @return A Some wrapped value of float configuration property if exists, otherwise None.
+     */
+    def getOptionalFloat: String => Option[Float] = getOptional(conf.getFloat)
+
+    /**
+     * Gets a value of double configuration property.
+     *
+     * @return A Some wrapped value of double configuration property if exists, otherwise None.
+     */
+    def getOptionalDouble: String => Option[Double] = getOptional(conf.getDouble)
+
+    private def getOptional[V](get: String => V)(key: String): Option[V] = {
+      if (conf.containsKey(key))
+        Option(get(key))
+      else
+        None
+    }
+
+  }
+
+  implicit class ConfigurationMapWrapper(val conf: Configuration) extends AnyVal {
+
+    /**
+     * Converts the configuration into map where keys are Strings and values are converted to U type.
+     * When the value key is not of proper type it throws.
+     *
+     * @tparam U type of values in returned map
+     * @return map representation of the configuration
+     */
+    def toMap[U: TypeTag]: Map[String, U] =
+      ConfigurationImplicits.toMap[U](conf)
+  }
+
+  /**
+   * This method needs to be defined outside of the Value class since Scala has issues with TypeTag in Value classes
+   */
+  private def toMap[U: TypeTag](conf: Configuration): Map[String, U] = {
+    val fun = typeOf[U] match {
+      case t if t =:= typeOf[String] => (c: Configuration, k: String) => c.getRequiredString(k)
+      case t if t =:= typeOf[Boolean] => (c: Configuration, k: String) => c.getRequiredBoolean(k)
+      case t if t =:= typeOf[BigDecimal] => (c: Configuration, k: String) => c.getRequiredBigDecimal(k)
+      case t if t =:= typeOf[Byte] => (c: Configuration, k: String) => c.getRequiredByte(k)
+      case t if t =:= typeOf[Short] => (c: Configuration, k: String) => c.getRequiredShort(k)
+      case t if t =:= typeOf[Int] => (c: Configuration, k: String) => c.getRequiredInt(k)
+      case t if t =:= typeOf[Long] => (c: Configuration, k: String) => c.getRequiredLong(k)
+      case t if t =:= typeOf[Float] => (c: Configuration, k: String) => c.getRequiredFloat(k)
+      case t if t =:= typeOf[Double] => (c: Configuration, k: String) => c.getRequiredDouble(k)
+      case t if t =:= typeOf[AnyRef] => (c: Configuration, k: String) => c.getProperty(k)
+      case t if t =:= typeOf[Array[String]] => (c: Configuration, k: String) => c.getRequiredStringArray(k)
+      case t => throw new UnsupportedOperationException(s"Type $t not supported")
+    }
+
+    conf
+      .getKeys.asScala
+      .map(k => k -> fun(conf, k).asInstanceOf[U])
+      .toMap
+  }
+
+
+}

--- a/commons/src/main/scala/za/co/absa/spline/common/TimeTracingUtils.scala
+++ b/commons/src/main/scala/za/co/absa/spline/common/TimeTracingUtils.scala
@@ -16,7 +16,7 @@
 
 package za.co.absa.spline.common
 
-import org.apache.commons.lang.time.StopWatch
+import org.apache.commons.lang3.time.StopWatch
 import org.slf4s.Logging
 
 object TimeTracingUtils extends Logging {

--- a/commons/src/main/scala/za/co/absa/spline/common/config/DefaultConfigurationStack.scala
+++ b/commons/src/main/scala/za/co/absa/spline/common/config/DefaultConfigurationStack.scala
@@ -16,8 +16,7 @@
 
 package za.co.absa.spline.common.config
 
-import org.apache.commons.configuration._
-import za.co.absa.commons.config.UpperSnakeCaseEnvironmentConfiguration
+import org.apache.commons.configuration2.{CompositeConfiguration, EnvironmentConfiguration, JNDIConfiguration, SystemConfiguration}
 import za.co.absa.spline.common.config.DefaultConfigurationStack.jndiConfigurationIfAvailable
 
 import java.util

--- a/commons/src/main/scala/za/co/absa/spline/common/config/UpperSnakeCaseEnvironmentConfiguration.scala
+++ b/commons/src/main/scala/za/co/absa/spline/common/config/UpperSnakeCaseEnvironmentConfiguration.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2025 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.spline.common.config
+
+import org.apache.commons.configuration2.EnvironmentConfiguration
+import org.apache.commons.lang3.StringUtils
+import za.co.absa.spline.common.config.UpperSnakeCaseEnvironmentConfiguration.toUpperSnake
+
+class UpperSnakeCaseEnvironmentConfiguration extends EnvironmentConfiguration {
+
+  override def getPropertyInternal(key: String): AnyRef = super.getPropertyInternal(toUpperSnake(key))
+
+  override def containsKeyInternal(key: String): Boolean = super.containsKeyInternal(toUpperSnake(key))
+}
+
+object UpperSnakeCaseEnvironmentConfiguration {
+  private def toUpperSnake(key: String) = {
+    key
+      .split("[\\W_]")
+      .flatMap(StringUtils.splitByCharacterTypeCamelCase)
+      .map(_.toUpperCase)
+      .mkString("_")
+  }
+}

--- a/commons/src/test/scala/za/co/absa/spline/common/config/ConfigurationImplicitsSpec.scala
+++ b/commons/src/test/scala/za/co/absa/spline/common/config/ConfigurationImplicitsSpec.scala
@@ -1,0 +1,285 @@
+/*
+ * Copyright 2025 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.spline.common.config
+
+import org.apache.commons.configuration2.convert.DefaultListDelimiterHandler
+import org.apache.commons.configuration2.{BaseConfiguration, MapConfiguration}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.net.URI
+
+class ConfigurationImplicitsSpec extends AnyFlatSpec with Matchers {
+
+  import org.apache.commons.configuration2.ConfigurationImplicits._
+
+  import scala.collection.JavaConverters._
+
+  behavior of "ConfigurationRequiredWrapper"
+
+  it should "implement getRequiredObject()" in {
+    val dummyObj = new {}
+    val configuration = new MapConfiguration(Map("foo" -> dummyObj, "bar" -> 42, "qux" -> null).asJava)
+    configuration getRequiredObject[AnyRef] "foo" should be theSameInstanceAs dummyObj
+    configuration getRequiredObject[Integer] "bar" should be theSameInstanceAs Int.box(42)
+    intercept[ClassCastException](configuration getRequiredObject[String] "bar").getMessage should (
+      include("java.lang.Integer") and include("java.lang.String")
+      )
+    intercept[NoSuchElementException](configuration getRequiredObject[AnyRef] "qux").getMessage should include("qux")
+    intercept[NoSuchElementException](configuration getRequiredObject[AnyRef] "oops").getMessage should include("oops")
+  }
+
+  it should "implement getRequiredString()" in {
+    val configuration = new MapConfiguration(Map("foo" -> "bar", "bla" -> "").asJava)
+    configuration getRequiredString "foo" should be("bar")
+    intercept[NoSuchElementException](configuration getRequiredString "bla").getMessage should include("bla")
+    intercept[NoSuchElementException](configuration getRequiredString "oops").getMessage should include("oops")
+  }
+
+  it should "implement getRequiredStringArray()" in {
+    val configuration = new MapConfiguration(Map("foo" -> "bar", "bla" -> "").asJava)
+    configuration getRequiredStringArray "foo" should be(Array("bar"))
+    intercept[NoSuchElementException](configuration getRequiredStringArray "bla").getMessage should include("bla")
+    intercept[NoSuchElementException](configuration getRequiredStringArray "oops").getMessage should include("oops")
+  }
+
+  it should "implement getRequiredBoolean()" in {
+    val configuration = new MapConfiguration(Map("foo" -> "true").asJava)
+    configuration getRequiredBoolean "foo" should be(true)
+    intercept[NoSuchElementException](configuration getRequiredBoolean "oops").getMessage should include("oops")
+  }
+
+  it should "implement getRequiredBigDecimal()" in {
+    val configuration = new MapConfiguration(Map("foo" -> "4.2").asJava)
+    configuration getRequiredBigDecimal "foo" should be(BigDecimal(4.2))
+    intercept[NoSuchElementException](configuration getRequiredBigDecimal "oops").getMessage should include("oops")
+  }
+
+  it should "implement getRequiredByte()" in {
+    val configuration = new MapConfiguration(Map("foo" -> "42").asJava)
+    configuration getRequiredByte "foo" should be(42.byteValue)
+    intercept[NoSuchElementException](configuration getRequiredByte "oops").getMessage should include("oops")
+  }
+
+  it should "implement getRequiredShort()" in {
+    val configuration = new MapConfiguration(Map("foo" -> "42").asJava)
+    configuration getRequiredShort "foo" should be(42.shortValue)
+    intercept[NoSuchElementException](configuration getRequiredShort "oops").getMessage should include("oops")
+  }
+
+  it should "implement getRequiredInt()" in {
+    val configuration = new MapConfiguration(Map("foo" -> "42").asJava)
+    configuration getRequiredInt "foo" should be(42.intValue)
+    intercept[NoSuchElementException](configuration getRequiredInt "oops").getMessage should include("oops")
+  }
+
+  it should "implement getRequiredLong()" in {
+    val configuration = new MapConfiguration(Map("foo" -> "42").asJava)
+    configuration getRequiredLong "foo" should be(42.longValue)
+    intercept[NoSuchElementException](configuration getRequiredLong "oops").getMessage should include("oops")
+  }
+
+  it should "implement getRequiredFloat()" in {
+    val configuration = new MapConfiguration(Map("foo" -> "4.2").asJava)
+    configuration getRequiredFloat "foo" should be(4.2.floatValue)
+    intercept[NoSuchElementException](configuration getRequiredFloat "oops").getMessage should include("oops")
+  }
+
+  it should "implement getRequiredDouble()" in {
+    val configuration = new MapConfiguration(Map("foo" -> "4.2").asJava)
+    configuration getRequiredDouble "foo" should be(4.2.doubleValue)
+    intercept[NoSuchElementException](configuration getRequiredDouble "oops").getMessage should include("oops")
+  }
+
+  it should "behave the same way regardless of `throwExceptionOnMissing` property settings" in {
+    Seq(false, true) foreach { b =>
+      val conf = new BaseConfiguration {
+        setThrowExceptionOnMissing(b)
+      }
+      intercept[NoSuchElementException](conf getRequiredString "oops").getMessage should include("oops")
+    }
+  }
+
+  it should "report the full missing property name in case of SubsetConfiguration" in {
+    val fooBarConf = new BaseConfiguration() subset "foo" subset "bar"
+    intercept[NoSuchElementException](fooBarConf getRequiredString "baz").getMessage should include("foo.bar.baz")
+  }
+
+  it should "propagate exceptions other than missing property" in {
+    object TestException extends Exception
+
+    val conf = new BaseConfiguration {
+      override def getPropertyInternal(key: String): AnyRef = throw TestException
+    }
+
+    the[RuntimeException] thrownBy conf.getRequiredInt("foo") should have(
+      'message("Error in retrieving configuration property foo"),
+      'cause(TestException))
+
+    the[RuntimeException] thrownBy conf.getRequiredBoolean("foo") should have(
+      'message("Error in retrieving configuration property foo"),
+      'cause(TestException))
+
+    the[RuntimeException] thrownBy conf.getRequiredString("foo") should have(
+      'message("Error in retrieving configuration property foo"),
+      'cause(TestException))
+
+    the[RuntimeException] thrownBy conf.getRequiredStringArray("foo") should have(
+      'message("Error in retrieving configuration property foo"),
+      'cause(TestException))
+  }
+
+  behavior of "ConfigurationOptionalWrapper"
+
+  it should "implement getOptionalObject()" in {
+    val configuration = new MapConfiguration(Map("foo" -> URI.create("http://www.example.com"), "bla" -> null, "bar" -> 42).asJava)
+    configuration getOptionalObject[URI] "foo" should be(Some(URI.create("http://www.example.com")))
+    configuration getOptionalObject[URI] "bla" should be(None)
+    configuration getOptionalObject[URI] "oops" should be(None)
+
+    intercept[ClassCastException](configuration.getOptionalObject[String]("bar").get).getMessage should (
+      include("java.lang.String") and include("java.lang.Integer")
+      )
+  }
+
+  it should "implement getOptionalString()" in {
+    val configuration = new MapConfiguration(Map("foo" -> "bar", "bla" -> "").asJava)
+    configuration getOptionalString "foo" should be(Some("bar"))
+    configuration getOptionalString "bla" should be(None)
+    configuration getOptionalString "oops" should be(None)
+  }
+
+  it should "implement getOptionalStringArray()" in {
+    val configuration = new MapConfiguration(Map("foo" -> "bar", "bla" -> "").asJava)
+    configuration.getOptionalStringArray("foo").get should be(Array("bar"))
+    configuration getOptionalString "bla" should be(None)
+    configuration getOptionalStringArray "oops" should be(None)
+  }
+
+  it should "implement getOptionalBoolean()" in {
+    val configuration = new MapConfiguration(Map("foo" -> "true").asJava)
+    configuration getOptionalBoolean "foo" should be(Some(true))
+    configuration getOptionalBoolean "oops" should be(None)
+  }
+
+  it should "implement getOptionalBigDecimal()" in {
+    val configuration = new MapConfiguration(Map("foo" -> "4.2").asJava)
+    configuration getOptionalBigDecimal "foo" should be(Some(BigDecimal(4.2)))
+    configuration getOptionalBigDecimal "oops" should be(None)
+  }
+
+  it should "implement getOptionalByte()" in {
+    val configuration = new MapConfiguration(Map("foo" -> "42").asJava)
+    configuration getOptionalByte "foo" should be(Some(42.byteValue))
+    configuration getOptionalByte "oops" should be(None)
+  }
+
+  it should "implement getOptionalShort()" in {
+    val configuration = new MapConfiguration(Map("foo" -> "42").asJava)
+    configuration getOptionalShort "foo" should be(Some(42.shortValue))
+    configuration getOptionalShort "oops" should be(None)
+  }
+
+  it should "implement getOptionalInt()" in {
+    val configuration = new MapConfiguration(Map("foo" -> "42").asJava)
+    configuration getOptionalInt "foo" should be(Some(42.intValue))
+    configuration getOptionalInt "oops" should be(None)
+  }
+
+  it should "implement getOptionalLong()" in {
+    val configuration = new MapConfiguration(Map("foo" -> "42").asJava)
+    configuration getOptionalLong "foo" should be(Some(42.longValue))
+    configuration getOptionalLong "oops" should be(None)
+  }
+
+  it should "implement getOptionalFloat()" in {
+    val configuration = new MapConfiguration(Map("foo" -> "4.2").asJava)
+    configuration getOptionalFloat "foo" should be(Some(4.2.floatValue))
+    configuration getOptionalFloat "oops" should be(None)
+  }
+
+  it should "implement getOptionalDouble()" in {
+    val configuration = new MapConfiguration(Map("foo" -> "4.2").asJava)
+    configuration getOptionalDouble "foo" should be(Some(4.2.doubleValue))
+    configuration getOptionalDouble "oops" should be(None)
+  }
+
+  it should "behave the same way regardless of `throwExceptionOnMissing` property settings" in {
+    Seq(false, true) foreach { b =>
+      val conf = new BaseConfiguration {
+        setThrowExceptionOnMissing(b)
+      }
+      conf getOptionalString "oops" should be(None)
+    }
+  }
+
+  behavior of "ConfigurationMapWrapper"
+
+  it should "implement convert config to map of Strings" in {
+    val configuration = new MapConfiguration(Map("foo" -> "1", "bar" -> "2").asJava)
+    val map = configuration.toMap[String]
+    map.apply("foo") should be("1")
+    map.apply("bar") should be("2")
+  }
+
+  it should "implement convert config to map of Integers" in {
+    val configuration = new MapConfiguration(Map("foo" -> "1", "bar" -> 2).asJava)
+    val map = configuration.toMap[Int]
+    map.apply("foo") should be(1)
+    map.apply("bar") should be(2)
+  }
+
+  it should "implement convert config to map of Longs" in {
+    val configuration = new MapConfiguration(Map("foo" -> "1", "bar" -> 2).asJava)
+    val map = configuration.toMap[Long]
+    map.apply("foo") should be(1L)
+    map.apply("bar") should be(2L)
+  }
+
+  it should "implement convert config to map of Booleans" in {
+    val configuration = new MapConfiguration(Map("foo" -> true, "bar" -> false).asJava)
+    val map = configuration.toMap[Boolean]
+    map.apply("foo") should be(true)
+    map.apply("bar") should be(false)
+  }
+
+  it should "implement convert config to map of AnyRefs" in {
+    val configuration = new MapConfiguration(Map("foo" -> "abc", "bar" -> 42).asJava)
+    val map = configuration.toMap[AnyRef]
+    map.apply("foo") should be("abc")
+    map.apply("bar") should be(42)
+  }
+
+  it should "implement convert config to map of Arrays of Strings" in {
+    val configuration = new MapConfiguration(Map("foo" -> "bar, zar, tar", "bla" -> "a").asJava)
+    configuration.setListDelimiterHandler(new DefaultListDelimiterHandler(','))
+    val map = configuration.toMap[Array[String]]
+
+    map.apply("foo") should be(Array("bar", "zar", "tar"))
+    map.apply("bla") should be(Array("a"))
+  }
+
+  it should "throw when one of the arrays is missing" in {
+    val configuration = new MapConfiguration(Map("foo" -> "bar, zar, tar", "bla" -> "").asJava)
+    intercept[NoSuchElementException](configuration.toMap[Array[String]]).getMessage should include("bla")
+  }
+
+  it should "throw when values in config doesn't match the requested type" in {
+    val configuration = new MapConfiguration(Map("foo" -> 42, "bar" -> false).asJava)
+    intercept[RuntimeException](configuration.toMap[Int])
+  }
+}

--- a/commons/src/test/scala/za/co/absa/spline/common/config/UpperSnakeCaseEnvironmentConfigurationSpec.scala
+++ b/commons/src/test/scala/za/co/absa/spline/common/config/UpperSnakeCaseEnvironmentConfigurationSpec.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2025 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.spline.common.config
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import za.co.absa.commons.scalatest.EnvFixture
+
+class UpperSnakeCaseEnvironmentConfigurationSpec
+  extends AnyFlatSpec
+    with Matchers
+    with EnvFixture {
+
+  it should "act as normal when given a key in format 'MY_VAR_NAME'" in {
+    setEnv("FOO_BAR_BAZ_42_QUX", "right")
+    (new UpperSnakeCaseEnvironmentConfiguration).containsKey("FOO_BAR_BAZ_42_QUX") should be(true)
+    (new UpperSnakeCaseEnvironmentConfiguration).getString("FOO_BAR_BAZ_42_QUX") should equal("right")
+  }
+
+  it should "ignore lower-case keys" in {
+    setEnv("foo.barBaz42.Qux", "wrong")
+    (new UpperSnakeCaseEnvironmentConfiguration).containsKey("foo.barBaz42.Qux") should be(false)
+    (new UpperSnakeCaseEnvironmentConfiguration).getString("foo.barBaz42.Qux") should be(null)
+  }
+
+  it should "convert keys per the environment variable naming convention, i.e 'my.varName' to 'MY_VAR_NAME'" in {
+    setEnv("FOO_BAR_BAZ_42_QUX", "right")
+    (new UpperSnakeCaseEnvironmentConfiguration).containsKey("foo.barBaz42.Qux") should be(true)
+    (new UpperSnakeCaseEnvironmentConfiguration).getString("foo.barBaz42.Qux") should equal("right")
+  }
+
+  it should "fix issue Spline-616" in {
+    setEnv("SPLINE_DATABASE_CONNECTION_URL", "right")
+    (new UpperSnakeCaseEnvironmentConfiguration).containsKey("spline.database.connectionUrl") should be(true)
+    (new UpperSnakeCaseEnvironmentConfiguration).getString("spline.database.connectionUrl") should equal("right")
+  }
+
+  it should "return null if non of the keys found" in {
+    (new UpperSnakeCaseEnvironmentConfiguration).containsKey("foo.barBaz42.Qux") should be(false)
+    (new UpperSnakeCaseEnvironmentConfiguration).getString("foo.barBaz42.Qux") should be(null)
+  }
+
+}

--- a/kafka-gateway/src/main/scala/za/co/absa/spline/gateway/kafka/KafkaGatewayConfig.scala
+++ b/kafka-gateway/src/main/scala/za/co/absa/spline/gateway/kafka/KafkaGatewayConfig.scala
@@ -19,7 +19,8 @@ package za.co.absa.spline.gateway.kafka
 import com.fasterxml.jackson.databind.{ObjectMapper, PropertyNamingStrategies}
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import com.twitter.finatra.jackson.FinatraInternalModules
-import org.apache.commons.configuration.ConfigurationConverter
+import org.apache.commons.configuration2.ConfigurationConverter
+import org.apache.commons.configuration2.ConfigurationImplicits._
 import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.common.serialization.{ByteArrayDeserializer, StringDeserializer}
 import org.springframework.context.annotation.{Bean, ComponentScan, Configuration}
@@ -33,7 +34,6 @@ import org.springframework.kafka.support.JacksonUtils
 import org.springframework.kafka.support.converter.Jackson2JavaTypeMapper.TypePrecedence
 import org.springframework.kafka.support.converter.{ByteArrayJsonMessageConverter, DefaultJackson2JavaTypeMapper, RecordMessageConverter}
 import za.co.absa.commons.config.ConfTyped
-import za.co.absa.commons.config.ConfigurationImplicits.{ConfigurationOptionalWrapper, ConfigurationRequiredWrapper}
 import za.co.absa.spline.common.config.DefaultConfigurationStack
 
 import java.util.concurrent.TimeUnit

--- a/persistence/src/main/scala/za/co/absa/spline/persistence/ArangoRepoConfig.scala
+++ b/persistence/src/main/scala/za/co/absa/spline/persistence/ArangoRepoConfig.scala
@@ -49,7 +49,7 @@ class ArangoRepoConfig extends InitializingBean with Logging {
 
 object ArangoRepoConfig extends DefaultConfigurationStack with ConfTyped {
 
-  import za.co.absa.commons.config.ConfigurationImplicits._
+  import org.apache.commons.configuration2.ConfigurationImplicits._
 
   override val rootPrefix: String = "spline"
 


### PR DESCRIPTION
Resolves #1419

- Migrate from Apache Commons Configuration version 1 to version 2
- Move two utility classes from the ABSA Commons to the local Commons module to be able to upgrade.
