### PR TITLE
spline #1431 Migrate to a new Maven Central Portal

### DIFF
--- a/build/parent-pom/pom.xml
+++ b/build/parent-pom/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>za.co.absa</groupId>
         <artifactId>root-pom</artifactId>
-        <version>1.0.14</version>
+        <version>1.1.0</version>
     </parent>
 
     <groupId>za.co.absa.spline</groupId>
@@ -29,7 +29,7 @@
     <packaging>pom</packaging>
 
     <scm>
-        <url>${scm.url}</url>
+        <url>https://github.com/AbsaOSS/spline</url>
         <connection>${scm.connection}</connection>
         <developerConnection>${scm.developerConnection}</developerConnection>
         <tag>HEAD</tag>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <packaging>pom</packaging>
 
     <scm>
-        <url>${scm.url}</url>
+        <url>https://github.com/AbsaOSS/spline</url>
         <connection>${scm.connection}</connection>
         <developerConnection>${scm.developerConnection}</developerConnection>
         <tag>HEAD</tag>
@@ -34,7 +34,7 @@
     <parent>
         <groupId>za.co.absa</groupId>
         <artifactId>root-pom</artifactId>
-        <version>1.0.14</version>
+        <version>1.1.0</version>
     </parent>
 
     <developers>


### PR DESCRIPTION
Fixes #1431 

- Upgrade `root-pom` to version `1.1.0`
- Fix `scm.url` property