### PR TITLE
issue #1455 Admin CLI :: must treat any 2xx return from the Producer …

### DIFF
--- a/commons/src/main/scala/za/co/absa/spline/common/rest/RESTClientApacheHttpImpl.scala
+++ b/commons/src/main/scala/za/co/absa/spline/common/rest/RESTClientApacheHttpImpl.scala
@@ -19,7 +19,7 @@ package za.co.absa.spline.common.rest
 import org.apache.commons.io.IOUtils
 import org.apache.http.Consts
 import org.apache.http.auth.Credentials
-import org.apache.http.client.methods.{CloseableHttpResponse, HttpDelete, HttpGet, HttpPost, HttpRequestBase}
+import org.apache.http.client.methods._
 import org.apache.http.conn.ssl.NoopHostnameVerifier
 import org.apache.http.entity.{AbstractHttpEntity, ByteArrayEntity, ContentType, StringEntity}
 import org.apache.http.impl.auth.BasicScheme
@@ -99,7 +99,7 @@ class RESTClientApacheHttpImpl(
       }
 
     respStatusLine.getStatusCode match {
-      case 200 | 201 | 204 =>
+      case code if (200 to 299) contains code =>
         respBody
       case _ =>
         throw new HttpStatusException(respStatusLine.getStatusCode, s"$respStatusLine $respBody", request.toString)


### PR DESCRIPTION
fixes #1455


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * All 2xx HTTP responses are now treated as success, not just 200/201/204. This prevents valid operations from being flagged as failures when services return other success codes (e.g., 202, 206), reducing false errors and retries.

* **Improvements**
  * More resilient REST response handling improves compatibility with diverse backends, resulting in smoother integrations and fewer disruptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->